### PR TITLE
Update to osv-schema 1.7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ With a few important exceptions, these fields correspond _exactly_ (including th
 
 ````md
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-1"
 modified = 2025-09-23T02:23:16.095Z
 published = 2025-09-23T02:23:16.095Z

--- a/advisories/published/2025/JLSEC-2025-1.md
+++ b/advisories/published/2025/JLSEC-2025-1.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-1"
 modified = 2025-10-08T17:41:37.190Z
 published = 2025-10-08T17:41:37.190Z

--- a/advisories/published/2025/JLSEC-2025-10.md
+++ b/advisories/published/2025/JLSEC-2025-10.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-10"
 modified = 2025-10-09T21:46:55.585Z
 published = 2025-10-09T21:46:55.585Z

--- a/advisories/published/2025/JLSEC-2025-100.md
+++ b/advisories/published/2025/JLSEC-2025-100.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-100"
 modified = 2025-10-19T18:40:48.457Z
 published = 2025-10-19T18:40:48.457Z

--- a/advisories/published/2025/JLSEC-2025-101.md
+++ b/advisories/published/2025/JLSEC-2025-101.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-101"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-102.md
+++ b/advisories/published/2025/JLSEC-2025-102.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-102"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-103.md
+++ b/advisories/published/2025/JLSEC-2025-103.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-103"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-104.md
+++ b/advisories/published/2025/JLSEC-2025-104.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-104"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-105.md
+++ b/advisories/published/2025/JLSEC-2025-105.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-105"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-106.md
+++ b/advisories/published/2025/JLSEC-2025-106.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-106"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-107.md
+++ b/advisories/published/2025/JLSEC-2025-107.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-107"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-108.md
+++ b/advisories/published/2025/JLSEC-2025-108.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-108"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-109.md
+++ b/advisories/published/2025/JLSEC-2025-109.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-109"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-11.md
+++ b/advisories/published/2025/JLSEC-2025-11.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-11"
 modified = 2025-10-09T21:46:55.585Z
 published = 2025-10-09T21:46:55.585Z

--- a/advisories/published/2025/JLSEC-2025-110.md
+++ b/advisories/published/2025/JLSEC-2025-110.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-110"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-111.md
+++ b/advisories/published/2025/JLSEC-2025-111.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-111"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-112.md
+++ b/advisories/published/2025/JLSEC-2025-112.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-112"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-113.md
+++ b/advisories/published/2025/JLSEC-2025-113.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-113"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-114.md
+++ b/advisories/published/2025/JLSEC-2025-114.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-114"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-115.md
+++ b/advisories/published/2025/JLSEC-2025-115.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-115"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-116.md
+++ b/advisories/published/2025/JLSEC-2025-116.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-116"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-117.md
+++ b/advisories/published/2025/JLSEC-2025-117.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-117"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-118.md
+++ b/advisories/published/2025/JLSEC-2025-118.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-118"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-119.md
+++ b/advisories/published/2025/JLSEC-2025-119.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-119"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-12.md
+++ b/advisories/published/2025/JLSEC-2025-12.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-12"
 modified = 2025-10-10T13:22:08.213Z
 published = 2025-10-10T13:22:08.213Z

--- a/advisories/published/2025/JLSEC-2025-120.md
+++ b/advisories/published/2025/JLSEC-2025-120.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-120"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-121.md
+++ b/advisories/published/2025/JLSEC-2025-121.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-121"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-122.md
+++ b/advisories/published/2025/JLSEC-2025-122.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-122"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-123.md
+++ b/advisories/published/2025/JLSEC-2025-123.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-123"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-124.md
+++ b/advisories/published/2025/JLSEC-2025-124.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-124"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-125.md
+++ b/advisories/published/2025/JLSEC-2025-125.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-125"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-126.md
+++ b/advisories/published/2025/JLSEC-2025-126.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-126"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-127.md
+++ b/advisories/published/2025/JLSEC-2025-127.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-127"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-128.md
+++ b/advisories/published/2025/JLSEC-2025-128.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-128"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-129.md
+++ b/advisories/published/2025/JLSEC-2025-129.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-129"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-13.md
+++ b/advisories/published/2025/JLSEC-2025-13.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-13"
 modified = 2025-10-10T13:22:08.213Z
 published = 2025-10-10T13:22:08.213Z

--- a/advisories/published/2025/JLSEC-2025-130.md
+++ b/advisories/published/2025/JLSEC-2025-130.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-130"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-131.md
+++ b/advisories/published/2025/JLSEC-2025-131.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-131"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-132.md
+++ b/advisories/published/2025/JLSEC-2025-132.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-132"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-133.md
+++ b/advisories/published/2025/JLSEC-2025-133.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-133"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-134.md
+++ b/advisories/published/2025/JLSEC-2025-134.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-134"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-135.md
+++ b/advisories/published/2025/JLSEC-2025-135.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-135"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-136.md
+++ b/advisories/published/2025/JLSEC-2025-136.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-136"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-137.md
+++ b/advisories/published/2025/JLSEC-2025-137.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-137"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-138.md
+++ b/advisories/published/2025/JLSEC-2025-138.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-138"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-139.md
+++ b/advisories/published/2025/JLSEC-2025-139.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-139"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-14.md
+++ b/advisories/published/2025/JLSEC-2025-14.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-14"
 modified = 2025-10-10T13:22:08.213Z
 published = 2025-10-10T13:22:08.213Z

--- a/advisories/published/2025/JLSEC-2025-140.md
+++ b/advisories/published/2025/JLSEC-2025-140.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-140"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-141.md
+++ b/advisories/published/2025/JLSEC-2025-141.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-141"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-142.md
+++ b/advisories/published/2025/JLSEC-2025-142.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-142"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-143.md
+++ b/advisories/published/2025/JLSEC-2025-143.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-143"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-144.md
+++ b/advisories/published/2025/JLSEC-2025-144.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-144"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-145.md
+++ b/advisories/published/2025/JLSEC-2025-145.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-145"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-146.md
+++ b/advisories/published/2025/JLSEC-2025-146.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-146"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-147.md
+++ b/advisories/published/2025/JLSEC-2025-147.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-147"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-148.md
+++ b/advisories/published/2025/JLSEC-2025-148.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-148"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-149.md
+++ b/advisories/published/2025/JLSEC-2025-149.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-149"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-15.md
+++ b/advisories/published/2025/JLSEC-2025-15.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-15"
 modified = 2025-10-10T13:22:08.213Z
 published = 2025-10-10T13:22:08.213Z

--- a/advisories/published/2025/JLSEC-2025-150.md
+++ b/advisories/published/2025/JLSEC-2025-150.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-150"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-151.md
+++ b/advisories/published/2025/JLSEC-2025-151.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-151"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-152.md
+++ b/advisories/published/2025/JLSEC-2025-152.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-152"
 modified = 2025-10-19T19:08:53.760Z
 published = 2025-10-19T19:08:53.760Z

--- a/advisories/published/2025/JLSEC-2025-153.md
+++ b/advisories/published/2025/JLSEC-2025-153.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-153"
 modified = 2025-10-19T22:31:43.957Z
 published = 2025-10-19T22:31:43.957Z

--- a/advisories/published/2025/JLSEC-2025-154.md
+++ b/advisories/published/2025/JLSEC-2025-154.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-154"
 modified = 2025-10-19T22:31:43.957Z
 published = 2025-10-19T22:31:43.957Z

--- a/advisories/published/2025/JLSEC-2025-155.md
+++ b/advisories/published/2025/JLSEC-2025-155.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-155"
 modified = 2025-10-19T22:31:43.957Z
 published = 2025-10-19T22:31:43.957Z

--- a/advisories/published/2025/JLSEC-2025-156.md
+++ b/advisories/published/2025/JLSEC-2025-156.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-156"
 modified = 2025-10-19T22:31:43.957Z
 published = 2025-10-19T22:31:43.957Z

--- a/advisories/published/2025/JLSEC-2025-157.md
+++ b/advisories/published/2025/JLSEC-2025-157.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-157"
 modified = 2025-10-19T22:31:43.957Z
 published = 2025-10-19T22:31:43.957Z

--- a/advisories/published/2025/JLSEC-2025-158.md
+++ b/advisories/published/2025/JLSEC-2025-158.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-158"
 modified = 2025-10-19T22:31:43.957Z
 published = 2025-10-19T22:31:43.957Z

--- a/advisories/published/2025/JLSEC-2025-159.md
+++ b/advisories/published/2025/JLSEC-2025-159.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-159"
 modified = 2025-10-19T22:31:43.957Z
 published = 2025-10-19T22:31:43.957Z

--- a/advisories/published/2025/JLSEC-2025-16.md
+++ b/advisories/published/2025/JLSEC-2025-16.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-16"
 modified = 2025-10-10T13:22:08.213Z
 published = 2025-10-10T13:22:08.213Z

--- a/advisories/published/2025/JLSEC-2025-160.md
+++ b/advisories/published/2025/JLSEC-2025-160.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-160"
 modified = 2025-10-19T22:31:43.957Z
 published = 2025-10-19T22:31:43.957Z

--- a/advisories/published/2025/JLSEC-2025-161.md
+++ b/advisories/published/2025/JLSEC-2025-161.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-161"
 modified = 2025-10-19T22:31:43.957Z
 published = 2025-10-19T22:31:43.957Z

--- a/advisories/published/2025/JLSEC-2025-162.md
+++ b/advisories/published/2025/JLSEC-2025-162.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-162"
 modified = 2025-10-19T22:31:43.957Z
 published = 2025-10-19T22:31:43.957Z

--- a/advisories/published/2025/JLSEC-2025-163.md
+++ b/advisories/published/2025/JLSEC-2025-163.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-163"
 modified = 2025-10-19T22:31:43.957Z
 published = 2025-10-19T22:31:43.957Z

--- a/advisories/published/2025/JLSEC-2025-164.md
+++ b/advisories/published/2025/JLSEC-2025-164.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-164"
 modified = 2025-10-19T22:31:43.957Z
 published = 2025-10-19T22:31:43.957Z

--- a/advisories/published/2025/JLSEC-2025-165.md
+++ b/advisories/published/2025/JLSEC-2025-165.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-165"
 modified = 2025-10-19T22:31:43.957Z
 published = 2025-10-19T22:31:43.957Z

--- a/advisories/published/2025/JLSEC-2025-166.md
+++ b/advisories/published/2025/JLSEC-2025-166.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-166"
 modified = 2025-10-19T22:31:43.957Z
 published = 2025-10-19T22:31:43.957Z

--- a/advisories/published/2025/JLSEC-2025-167.md
+++ b/advisories/published/2025/JLSEC-2025-167.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-167"
 modified = 2025-10-19T22:31:43.957Z
 published = 2025-10-19T22:31:43.957Z

--- a/advisories/published/2025/JLSEC-2025-168.md
+++ b/advisories/published/2025/JLSEC-2025-168.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-168"
 modified = 2025-10-19T22:31:43.957Z
 published = 2025-10-19T22:31:43.957Z

--- a/advisories/published/2025/JLSEC-2025-169.md
+++ b/advisories/published/2025/JLSEC-2025-169.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-169"
 modified = 2025-10-20T22:55:27.993Z
 published = 2025-10-20T22:55:27.993Z

--- a/advisories/published/2025/JLSEC-2025-17.md
+++ b/advisories/published/2025/JLSEC-2025-17.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-17"
 modified = 2025-10-10T13:22:08.213Z
 published = 2025-10-10T13:22:08.213Z

--- a/advisories/published/2025/JLSEC-2025-170.md
+++ b/advisories/published/2025/JLSEC-2025-170.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-170"
 modified = 2025-10-20T22:55:27.993Z
 published = 2025-10-20T22:55:27.993Z

--- a/advisories/published/2025/JLSEC-2025-171.md
+++ b/advisories/published/2025/JLSEC-2025-171.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-171"
 modified = 2025-10-20T22:55:27.993Z
 published = 2025-10-20T22:55:27.993Z

--- a/advisories/published/2025/JLSEC-2025-172.md
+++ b/advisories/published/2025/JLSEC-2025-172.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-172"
 modified = 2025-10-20T22:55:27.993Z
 published = 2025-10-20T22:55:27.993Z

--- a/advisories/published/2025/JLSEC-2025-173.md
+++ b/advisories/published/2025/JLSEC-2025-173.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-173"
 modified = 2025-10-21T14:51:00.329Z
 published = 2025-10-21T14:51:00.329Z

--- a/advisories/published/2025/JLSEC-2025-174.md
+++ b/advisories/published/2025/JLSEC-2025-174.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-174"
 modified = 2025-10-21T17:24:37.757Z
 published = 2025-10-21T17:24:37.757Z

--- a/advisories/published/2025/JLSEC-2025-175.md
+++ b/advisories/published/2025/JLSEC-2025-175.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-175"
 modified = 2025-10-21T17:24:37.757Z
 published = 2025-10-21T17:24:37.757Z

--- a/advisories/published/2025/JLSEC-2025-176.md
+++ b/advisories/published/2025/JLSEC-2025-176.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-176"
 modified = 2025-10-21T17:35:18.006Z
 published = 2025-10-21T17:35:18.006Z

--- a/advisories/published/2025/JLSEC-2025-177.md
+++ b/advisories/published/2025/JLSEC-2025-177.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-177"
 modified = 2025-10-21T17:39:06.495Z
 published = 2025-10-21T17:39:06.495Z

--- a/advisories/published/2025/JLSEC-2025-178.md
+++ b/advisories/published/2025/JLSEC-2025-178.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-178"
 modified = 2025-10-21T17:39:06.495Z
 published = 2025-10-21T17:39:06.495Z

--- a/advisories/published/2025/JLSEC-2025-179.md
+++ b/advisories/published/2025/JLSEC-2025-179.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-179"
 modified = 2025-10-21T17:39:06.495Z
 published = 2025-10-21T17:39:06.495Z

--- a/advisories/published/2025/JLSEC-2025-18.md
+++ b/advisories/published/2025/JLSEC-2025-18.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-18"
 modified = 2025-10-10T14:27:45.619Z
 published = 2025-10-10T14:27:45.619Z

--- a/advisories/published/2025/JLSEC-2025-180.md
+++ b/advisories/published/2025/JLSEC-2025-180.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-180"
 modified = 2025-10-21T17:39:06.495Z
 published = 2025-10-21T17:39:06.495Z

--- a/advisories/published/2025/JLSEC-2025-181.md
+++ b/advisories/published/2025/JLSEC-2025-181.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-181"
 modified = 2025-10-21T17:50:47.064Z
 published = 2025-10-21T17:50:47.064Z

--- a/advisories/published/2025/JLSEC-2025-182.md
+++ b/advisories/published/2025/JLSEC-2025-182.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-182"
 modified = 2025-10-21T19:17:09.363Z
 published = 2025-10-21T19:17:09.363Z

--- a/advisories/published/2025/JLSEC-2025-183.md
+++ b/advisories/published/2025/JLSEC-2025-183.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-183"
 modified = 2025-10-21T19:17:09.363Z
 published = 2025-10-21T19:17:09.363Z

--- a/advisories/published/2025/JLSEC-2025-184.md
+++ b/advisories/published/2025/JLSEC-2025-184.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-184"
 modified = 2025-10-21T19:17:09.363Z
 published = 2025-10-21T19:17:09.363Z

--- a/advisories/published/2025/JLSEC-2025-185.md
+++ b/advisories/published/2025/JLSEC-2025-185.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-185"
 modified = 2025-10-21T19:17:09.363Z
 published = 2025-10-21T19:17:09.363Z

--- a/advisories/published/2025/JLSEC-2025-186.md
+++ b/advisories/published/2025/JLSEC-2025-186.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-186"
 modified = 2025-10-21T19:17:09.363Z
 published = 2025-10-21T19:17:09.363Z

--- a/advisories/published/2025/JLSEC-2025-187.md
+++ b/advisories/published/2025/JLSEC-2025-187.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-187"
 modified = 2025-10-23T17:26:52.088Z
 published = 2025-10-23T17:26:52.088Z

--- a/advisories/published/2025/JLSEC-2025-188.md
+++ b/advisories/published/2025/JLSEC-2025-188.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-188"
 modified = 2025-10-27T15:45:54.694Z
 published = 2025-10-27T15:45:54.694Z

--- a/advisories/published/2025/JLSEC-2025-189.md
+++ b/advisories/published/2025/JLSEC-2025-189.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-189"
 modified = 2025-10-27T15:45:54.694Z
 published = 2025-10-27T15:45:54.694Z

--- a/advisories/published/2025/JLSEC-2025-19.md
+++ b/advisories/published/2025/JLSEC-2025-19.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-19"
 modified = 2025-10-10T14:27:45.619Z
 published = 2025-10-10T14:27:45.619Z

--- a/advisories/published/2025/JLSEC-2025-190.md
+++ b/advisories/published/2025/JLSEC-2025-190.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-190"
 modified = 2025-10-27T18:23:36.019Z
 published = 2025-10-27T18:23:36.019Z

--- a/advisories/published/2025/JLSEC-2025-191.md
+++ b/advisories/published/2025/JLSEC-2025-191.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-191"
 modified = 2025-10-27T18:23:36.019Z
 published = 2025-10-27T18:23:36.019Z

--- a/advisories/published/2025/JLSEC-2025-192.md
+++ b/advisories/published/2025/JLSEC-2025-192.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-192"
 modified = 2025-10-27T18:23:36.019Z
 published = 2025-10-27T18:23:36.019Z

--- a/advisories/published/2025/JLSEC-2025-193.md
+++ b/advisories/published/2025/JLSEC-2025-193.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-193"
 modified = 2025-10-27T18:23:36.019Z
 published = 2025-10-27T18:23:36.019Z

--- a/advisories/published/2025/JLSEC-2025-194.md
+++ b/advisories/published/2025/JLSEC-2025-194.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-194"
 modified = 2025-10-27T18:23:36.019Z
 published = 2025-10-27T18:23:36.019Z

--- a/advisories/published/2025/JLSEC-2025-195.md
+++ b/advisories/published/2025/JLSEC-2025-195.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-195"
 modified = 2025-10-28T13:50:46.694Z
 published = 2025-10-28T13:50:46.694Z

--- a/advisories/published/2025/JLSEC-2025-196.md
+++ b/advisories/published/2025/JLSEC-2025-196.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-196"
 modified = 2025-10-28T19:36:40.815Z
 published = 2025-10-28T13:50:46.694Z

--- a/advisories/published/2025/JLSEC-2025-2.md
+++ b/advisories/published/2025/JLSEC-2025-2.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-2"
 modified = 2025-10-08T17:41:37.190Z
 published = 2025-10-08T17:41:37.190Z

--- a/advisories/published/2025/JLSEC-2025-20.md
+++ b/advisories/published/2025/JLSEC-2025-20.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-20"
 modified = 2025-10-10T14:27:45.619Z
 published = 2025-10-10T14:27:45.619Z

--- a/advisories/published/2025/JLSEC-2025-21.md
+++ b/advisories/published/2025/JLSEC-2025-21.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-21"
 modified = 2025-10-10T14:27:45.619Z
 published = 2025-10-10T14:27:45.619Z

--- a/advisories/published/2025/JLSEC-2025-22.md
+++ b/advisories/published/2025/JLSEC-2025-22.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-22"
 modified = 2025-10-10T14:27:45.619Z
 published = 2025-10-10T14:27:45.619Z

--- a/advisories/published/2025/JLSEC-2025-23.md
+++ b/advisories/published/2025/JLSEC-2025-23.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-23"
 modified = 2025-10-10T15:04:01.319Z
 published = 2025-10-10T15:04:01.319Z

--- a/advisories/published/2025/JLSEC-2025-24.md
+++ b/advisories/published/2025/JLSEC-2025-24.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-24"
 modified = 2025-10-10T15:04:01.319Z
 published = 2025-10-10T15:04:01.319Z

--- a/advisories/published/2025/JLSEC-2025-25.md
+++ b/advisories/published/2025/JLSEC-2025-25.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-25"
 modified = 2025-10-10T15:04:01.319Z
 published = 2025-10-10T15:04:01.319Z

--- a/advisories/published/2025/JLSEC-2025-26.md
+++ b/advisories/published/2025/JLSEC-2025-26.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-26"
 modified = 2025-10-10T15:04:01.319Z
 published = 2025-10-10T15:04:01.319Z

--- a/advisories/published/2025/JLSEC-2025-27.md
+++ b/advisories/published/2025/JLSEC-2025-27.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-27"
 modified = 2025-10-10T15:04:01.319Z
 published = 2025-10-10T15:04:01.319Z

--- a/advisories/published/2025/JLSEC-2025-28.md
+++ b/advisories/published/2025/JLSEC-2025-28.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-28"
 modified = 2025-10-10T15:04:01.319Z
 published = 2025-10-10T15:04:01.319Z

--- a/advisories/published/2025/JLSEC-2025-29.md
+++ b/advisories/published/2025/JLSEC-2025-29.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-29"
 modified = 2025-10-10T15:04:01.319Z
 published = 2025-10-10T15:04:01.319Z

--- a/advisories/published/2025/JLSEC-2025-3.md
+++ b/advisories/published/2025/JLSEC-2025-3.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-3"
 modified = 2025-10-08T17:41:37.190Z
 published = 2025-10-08T17:41:37.190Z

--- a/advisories/published/2025/JLSEC-2025-30.md
+++ b/advisories/published/2025/JLSEC-2025-30.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-30"
 modified = 2025-10-10T15:04:01.319Z
 published = 2025-10-10T15:04:01.319Z

--- a/advisories/published/2025/JLSEC-2025-31.md
+++ b/advisories/published/2025/JLSEC-2025-31.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-31"
 modified = 2025-10-10T15:04:01.319Z
 published = 2025-10-10T15:04:01.319Z

--- a/advisories/published/2025/JLSEC-2025-32.md
+++ b/advisories/published/2025/JLSEC-2025-32.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-32"
 modified = 2025-10-10T15:04:01.319Z
 published = 2025-10-10T15:04:01.319Z

--- a/advisories/published/2025/JLSEC-2025-33.md
+++ b/advisories/published/2025/JLSEC-2025-33.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-33"
 modified = 2025-10-10T15:04:01.319Z
 published = 2025-10-10T15:04:01.319Z

--- a/advisories/published/2025/JLSEC-2025-34.md
+++ b/advisories/published/2025/JLSEC-2025-34.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-34"
 modified = 2025-10-10T15:04:01.319Z
 published = 2025-10-10T15:04:01.319Z

--- a/advisories/published/2025/JLSEC-2025-35.md
+++ b/advisories/published/2025/JLSEC-2025-35.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-35"
 modified = 2025-10-10T15:04:01.319Z
 published = 2025-10-10T15:04:01.319Z

--- a/advisories/published/2025/JLSEC-2025-36.md
+++ b/advisories/published/2025/JLSEC-2025-36.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-36"
 modified = 2025-10-10T15:04:01.319Z
 published = 2025-10-10T15:04:01.319Z

--- a/advisories/published/2025/JLSEC-2025-37.md
+++ b/advisories/published/2025/JLSEC-2025-37.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-37"
 modified = 2025-10-10T15:04:01.319Z
 published = 2025-10-10T15:04:01.319Z

--- a/advisories/published/2025/JLSEC-2025-38.md
+++ b/advisories/published/2025/JLSEC-2025-38.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-38"
 modified = 2025-10-10T15:04:01.319Z
 published = 2025-10-10T15:04:01.319Z

--- a/advisories/published/2025/JLSEC-2025-39.md
+++ b/advisories/published/2025/JLSEC-2025-39.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-39"
 modified = 2025-10-14T04:37:19.606Z
 published = 2025-10-14T04:37:19.606Z

--- a/advisories/published/2025/JLSEC-2025-4.md
+++ b/advisories/published/2025/JLSEC-2025-4.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-4"
 modified = 2025-10-08T17:41:37.190Z
 published = 2025-10-08T17:41:37.190Z

--- a/advisories/published/2025/JLSEC-2025-40.md
+++ b/advisories/published/2025/JLSEC-2025-40.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-40"
 modified = 2025-10-14T04:37:19.606Z
 published = 2025-10-14T04:37:19.606Z

--- a/advisories/published/2025/JLSEC-2025-41.md
+++ b/advisories/published/2025/JLSEC-2025-41.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-41"
 modified = 2025-10-14T15:35:41.198Z
 published = 2025-10-14T15:35:41.198Z

--- a/advisories/published/2025/JLSEC-2025-42.md
+++ b/advisories/published/2025/JLSEC-2025-42.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-42"
 modified = 2025-10-14T15:35:41.198Z
 published = 2025-10-14T15:35:41.198Z

--- a/advisories/published/2025/JLSEC-2025-43.md
+++ b/advisories/published/2025/JLSEC-2025-43.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-43"
 modified = 2025-10-14T15:35:41.198Z
 published = 2025-10-14T15:35:41.198Z

--- a/advisories/published/2025/JLSEC-2025-44.md
+++ b/advisories/published/2025/JLSEC-2025-44.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-44"
 modified = 2025-10-14T15:35:41.198Z
 published = 2025-10-14T15:35:41.198Z

--- a/advisories/published/2025/JLSEC-2025-45.md
+++ b/advisories/published/2025/JLSEC-2025-45.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-45"
 modified = 2025-10-14T15:35:41.198Z
 published = 2025-10-14T15:35:41.198Z

--- a/advisories/published/2025/JLSEC-2025-46.md
+++ b/advisories/published/2025/JLSEC-2025-46.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-46"
 modified = 2025-10-14T15:35:41.198Z
 published = 2025-10-14T15:35:41.198Z

--- a/advisories/published/2025/JLSEC-2025-47.md
+++ b/advisories/published/2025/JLSEC-2025-47.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-47"
 modified = 2025-10-14T15:35:41.198Z
 published = 2025-10-14T15:35:41.198Z

--- a/advisories/published/2025/JLSEC-2025-48.md
+++ b/advisories/published/2025/JLSEC-2025-48.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-48"
 modified = 2025-10-14T15:35:41.198Z
 published = 2025-10-14T15:35:41.198Z

--- a/advisories/published/2025/JLSEC-2025-49.md
+++ b/advisories/published/2025/JLSEC-2025-49.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-49"
 modified = 2025-10-14T15:35:41.198Z
 published = 2025-10-14T15:35:41.198Z

--- a/advisories/published/2025/JLSEC-2025-5.md
+++ b/advisories/published/2025/JLSEC-2025-5.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-5"
 modified = 2025-10-08T17:41:37.190Z
 published = 2025-10-08T17:41:37.190Z

--- a/advisories/published/2025/JLSEC-2025-50.md
+++ b/advisories/published/2025/JLSEC-2025-50.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-50"
 modified = 2025-10-14T15:35:41.198Z
 published = 2025-10-14T15:35:41.198Z

--- a/advisories/published/2025/JLSEC-2025-51.md
+++ b/advisories/published/2025/JLSEC-2025-51.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-51"
 modified = 2025-10-14T15:35:41.198Z
 published = 2025-10-14T15:35:41.198Z

--- a/advisories/published/2025/JLSEC-2025-52.md
+++ b/advisories/published/2025/JLSEC-2025-52.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-52"
 modified = 2025-10-14T15:35:41.198Z
 published = 2025-10-14T15:35:41.198Z

--- a/advisories/published/2025/JLSEC-2025-53.md
+++ b/advisories/published/2025/JLSEC-2025-53.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-53"
 modified = 2025-10-14T15:35:41.198Z
 published = 2025-10-14T15:35:41.198Z

--- a/advisories/published/2025/JLSEC-2025-54.md
+++ b/advisories/published/2025/JLSEC-2025-54.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-54"
 modified = 2025-10-14T15:35:41.198Z
 published = 2025-10-14T15:35:41.198Z

--- a/advisories/published/2025/JLSEC-2025-55.md
+++ b/advisories/published/2025/JLSEC-2025-55.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-55"
 modified = 2025-10-14T15:35:41.198Z
 published = 2025-10-14T15:35:41.198Z

--- a/advisories/published/2025/JLSEC-2025-56.md
+++ b/advisories/published/2025/JLSEC-2025-56.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-56"
 modified = 2025-10-14T15:35:41.198Z
 published = 2025-10-14T15:35:41.198Z

--- a/advisories/published/2025/JLSEC-2025-57.md
+++ b/advisories/published/2025/JLSEC-2025-57.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-57"
 modified = 2025-10-14T15:35:41.198Z
 published = 2025-10-14T15:35:41.198Z

--- a/advisories/published/2025/JLSEC-2025-58.md
+++ b/advisories/published/2025/JLSEC-2025-58.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-58"
 modified = 2025-10-14T15:35:41.198Z
 published = 2025-10-14T15:35:41.198Z

--- a/advisories/published/2025/JLSEC-2025-59.md
+++ b/advisories/published/2025/JLSEC-2025-59.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-59"
 modified = 2025-10-14T15:35:41.198Z
 published = 2025-10-14T15:35:41.198Z

--- a/advisories/published/2025/JLSEC-2025-6.md
+++ b/advisories/published/2025/JLSEC-2025-6.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-6"
 modified = 2025-10-08T17:41:37.190Z
 published = 2025-10-08T17:41:37.190Z

--- a/advisories/published/2025/JLSEC-2025-60.md
+++ b/advisories/published/2025/JLSEC-2025-60.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-60"
 modified = 2025-10-14T15:35:41.198Z
 published = 2025-10-14T15:35:41.198Z

--- a/advisories/published/2025/JLSEC-2025-61.md
+++ b/advisories/published/2025/JLSEC-2025-61.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-61"
 modified = 2025-10-14T15:35:41.198Z
 published = 2025-10-14T15:35:41.198Z

--- a/advisories/published/2025/JLSEC-2025-62.md
+++ b/advisories/published/2025/JLSEC-2025-62.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-62"
 modified = 2025-10-14T15:35:41.198Z
 published = 2025-10-14T15:35:41.198Z

--- a/advisories/published/2025/JLSEC-2025-63.md
+++ b/advisories/published/2025/JLSEC-2025-63.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-63"
 modified = 2025-10-14T15:35:41.198Z
 published = 2025-10-14T15:35:41.198Z

--- a/advisories/published/2025/JLSEC-2025-64.md
+++ b/advisories/published/2025/JLSEC-2025-64.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-64"
 modified = 2025-10-14T15:35:41.198Z
 published = 2025-10-14T15:35:41.198Z

--- a/advisories/published/2025/JLSEC-2025-65.md
+++ b/advisories/published/2025/JLSEC-2025-65.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-65"
 modified = 2025-10-17T13:28:40.708Z
 published = 2025-10-17T13:28:40.708Z

--- a/advisories/published/2025/JLSEC-2025-66.md
+++ b/advisories/published/2025/JLSEC-2025-66.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-66"
 modified = 2025-10-28T19:36:40.815Z
 published = 2025-10-17T17:40:51.659Z

--- a/advisories/published/2025/JLSEC-2025-67.md
+++ b/advisories/published/2025/JLSEC-2025-67.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-67"
 modified = 2025-10-28T19:36:40.815Z
 published = 2025-10-17T17:40:51.659Z

--- a/advisories/published/2025/JLSEC-2025-68.md
+++ b/advisories/published/2025/JLSEC-2025-68.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-68"
 modified = 2025-10-28T19:36:40.815Z
 published = 2025-10-17T17:40:51.659Z

--- a/advisories/published/2025/JLSEC-2025-69.md
+++ b/advisories/published/2025/JLSEC-2025-69.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-69"
 modified = 2025-10-28T19:36:40.815Z
 published = 2025-10-17T17:40:51.659Z

--- a/advisories/published/2025/JLSEC-2025-7.md
+++ b/advisories/published/2025/JLSEC-2025-7.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-7"
 modified = 2025-10-09T17:08:38.385Z
 published = 2025-10-09T17:08:38.385Z

--- a/advisories/published/2025/JLSEC-2025-70.md
+++ b/advisories/published/2025/JLSEC-2025-70.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-70"
 modified = 2025-10-28T19:36:40.815Z
 published = 2025-10-17T17:40:51.659Z

--- a/advisories/published/2025/JLSEC-2025-71.md
+++ b/advisories/published/2025/JLSEC-2025-71.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-71"
 modified = 2025-10-28T19:36:40.815Z
 published = 2025-10-17T17:40:51.659Z

--- a/advisories/published/2025/JLSEC-2025-72.md
+++ b/advisories/published/2025/JLSEC-2025-72.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-72"
 modified = 2025-10-28T19:36:40.815Z
 published = 2025-10-17T17:40:51.659Z

--- a/advisories/published/2025/JLSEC-2025-73.md
+++ b/advisories/published/2025/JLSEC-2025-73.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-73"
 modified = 2025-10-28T19:36:40.815Z
 published = 2025-10-17T17:40:51.659Z

--- a/advisories/published/2025/JLSEC-2025-74.md
+++ b/advisories/published/2025/JLSEC-2025-74.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-74"
 modified = 2025-10-28T19:36:40.815Z
 published = 2025-10-17T17:40:51.659Z

--- a/advisories/published/2025/JLSEC-2025-75.md
+++ b/advisories/published/2025/JLSEC-2025-75.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-75"
 modified = 2025-10-28T19:36:40.815Z
 published = 2025-10-17T17:40:51.659Z

--- a/advisories/published/2025/JLSEC-2025-76.md
+++ b/advisories/published/2025/JLSEC-2025-76.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-76"
 modified = 2025-10-28T19:36:40.815Z
 published = 2025-10-17T17:40:51.659Z

--- a/advisories/published/2025/JLSEC-2025-77.md
+++ b/advisories/published/2025/JLSEC-2025-77.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-77"
 modified = 2025-10-28T19:36:40.815Z
 published = 2025-10-17T17:40:51.659Z

--- a/advisories/published/2025/JLSEC-2025-78.md
+++ b/advisories/published/2025/JLSEC-2025-78.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-78"
 modified = 2025-10-28T19:36:40.815Z
 published = 2025-10-17T17:40:51.659Z

--- a/advisories/published/2025/JLSEC-2025-79.md
+++ b/advisories/published/2025/JLSEC-2025-79.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-79"
 modified = 2025-10-28T19:36:40.815Z
 published = 2025-10-17T17:40:51.659Z

--- a/advisories/published/2025/JLSEC-2025-8.md
+++ b/advisories/published/2025/JLSEC-2025-8.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-8"
 modified = 2025-10-09T17:08:38.385Z
 published = 2025-10-09T17:08:38.385Z

--- a/advisories/published/2025/JLSEC-2025-80.md
+++ b/advisories/published/2025/JLSEC-2025-80.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-80"
 modified = 2025-10-28T19:36:40.815Z
 published = 2025-10-17T17:40:51.659Z

--- a/advisories/published/2025/JLSEC-2025-81.md
+++ b/advisories/published/2025/JLSEC-2025-81.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-81"
 modified = 2025-10-28T19:36:40.815Z
 published = 2025-10-17T17:40:51.659Z

--- a/advisories/published/2025/JLSEC-2025-82.md
+++ b/advisories/published/2025/JLSEC-2025-82.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-82"
 modified = 2025-10-28T19:36:40.815Z
 published = 2025-10-17T17:40:51.659Z

--- a/advisories/published/2025/JLSEC-2025-83.md
+++ b/advisories/published/2025/JLSEC-2025-83.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-83"
 modified = 2025-10-28T19:36:40.815Z
 published = 2025-10-17T17:40:51.659Z

--- a/advisories/published/2025/JLSEC-2025-84.md
+++ b/advisories/published/2025/JLSEC-2025-84.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-84"
 modified = 2025-10-28T19:36:40.815Z
 published = 2025-10-17T17:40:51.659Z

--- a/advisories/published/2025/JLSEC-2025-85.md
+++ b/advisories/published/2025/JLSEC-2025-85.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-85"
 modified = 2025-10-28T19:36:40.815Z
 published = 2025-10-17T17:40:51.659Z

--- a/advisories/published/2025/JLSEC-2025-86.md
+++ b/advisories/published/2025/JLSEC-2025-86.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-86"
 modified = 2025-10-28T19:36:40.815Z
 published = 2025-10-17T17:40:51.659Z

--- a/advisories/published/2025/JLSEC-2025-87.md
+++ b/advisories/published/2025/JLSEC-2025-87.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-87"
 modified = 2025-10-28T19:36:40.815Z
 published = 2025-10-17T17:40:51.659Z

--- a/advisories/published/2025/JLSEC-2025-88.md
+++ b/advisories/published/2025/JLSEC-2025-88.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-88"
 modified = 2025-10-28T19:36:40.815Z
 published = 2025-10-17T17:40:51.659Z

--- a/advisories/published/2025/JLSEC-2025-89.md
+++ b/advisories/published/2025/JLSEC-2025-89.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-89"
 modified = 2025-10-28T19:36:40.815Z
 published = 2025-10-17T17:40:51.659Z

--- a/advisories/published/2025/JLSEC-2025-9.md
+++ b/advisories/published/2025/JLSEC-2025-9.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-9"
 modified = 2025-10-09T17:12:21.975Z
 published = 2025-10-09T17:12:21.975Z

--- a/advisories/published/2025/JLSEC-2025-90.md
+++ b/advisories/published/2025/JLSEC-2025-90.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-90"
 modified = 2025-10-28T19:36:40.815Z
 published = 2025-10-17T17:40:51.659Z

--- a/advisories/published/2025/JLSEC-2025-91.md
+++ b/advisories/published/2025/JLSEC-2025-91.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-91"
 modified = 2025-10-28T19:36:40.815Z
 published = 2025-10-17T17:40:51.659Z

--- a/advisories/published/2025/JLSEC-2025-92.md
+++ b/advisories/published/2025/JLSEC-2025-92.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-92"
 modified = 2025-10-17T22:31:47.919Z
 published = 2025-10-17T22:31:47.919Z

--- a/advisories/published/2025/JLSEC-2025-93.md
+++ b/advisories/published/2025/JLSEC-2025-93.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-93"
 modified = 2025-10-17T22:31:47.919Z
 published = 2025-10-17T22:31:47.919Z

--- a/advisories/published/2025/JLSEC-2025-94.md
+++ b/advisories/published/2025/JLSEC-2025-94.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-94"
 modified = 2025-10-17T22:31:47.919Z
 published = 2025-10-17T22:31:47.919Z

--- a/advisories/published/2025/JLSEC-2025-95.md
+++ b/advisories/published/2025/JLSEC-2025-95.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-95"
 modified = 2025-10-19T18:40:48.457Z
 published = 2025-10-19T18:40:48.457Z

--- a/advisories/published/2025/JLSEC-2025-96.md
+++ b/advisories/published/2025/JLSEC-2025-96.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-96"
 modified = 2025-10-28T13:50:46.694Z
 published = 2025-10-19T18:40:48.457Z

--- a/advisories/published/2025/JLSEC-2025-97.md
+++ b/advisories/published/2025/JLSEC-2025-97.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-97"
 modified = 2025-10-19T18:40:48.457Z
 published = 2025-10-19T18:40:48.457Z

--- a/advisories/published/2025/JLSEC-2025-98.md
+++ b/advisories/published/2025/JLSEC-2025-98.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-98"
 modified = 2025-10-19T18:40:48.457Z
 published = 2025-10-19T18:40:48.457Z

--- a/advisories/published/2025/JLSEC-2025-99.md
+++ b/advisories/published/2025/JLSEC-2025-99.md
@@ -1,5 +1,5 @@
 ```toml
-schema_version = "1.7.3"
+schema_version = "1.7.4"
 id = "JLSEC-2025-99"
 modified = 2025-10-19T18:40:48.457Z
 published = 2025-10-19T18:40:48.457Z

--- a/src/advisory.jl
+++ b/src/advisory.jl
@@ -145,7 +145,7 @@ There is just one place where we differ:
 """
 @kwdef mutable struct Advisory
     ## OSV fields
-    schema_version::String = "1.7.3"
+    schema_version::String = "1.7.4"
     # The identifier and dates are re-written by GitHub Actions upon publication and modification
     id::String = string(PREFIX, "-0000-", string(Dates.datetime2epochms(Dates.now()), base=36), "-", string(rand(UInt32), base=36))
     modified::DateTime = Dates.now(Dates.UTC)


### PR DESCRIPTION
> 2025-10-27 Released version 1.7.4. Add the following prefixes: EFF (Erlang), JLSEC (Julia), ALPINE-, DEBIAN-.