### PR TITLE
Withdraw JLSEC-2025-181

### DIFF
--- a/advisories/published/2025/JLSEC-2025-181.md
+++ b/advisories/published/2025/JLSEC-2025-181.md
@@ -3,6 +3,7 @@ schema_version = "1.7.4"
 id = "JLSEC-2025-181"
 modified = 2025-10-31T18:41:21.318Z
 published = 2025-10-21T17:50:47.064Z
+withdrawn = 2026-03-13T00:00:00Z
 upstream = ["CVE-2022-26345"]
 references = ["http://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00674.html", "http://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00674.html"]
 


### PR DESCRIPTION
This CVE only applies to the oneapi toolkit flavors of OpenMP, whereas our IntelOpenMP_jll has always downloaded Python's distribution: https://github.com/JuliaRegistries/GeneralMetadata.jl/blob/91f7e8170bb6b4ada8cf73ad95fe03d858b7f945/metadata/I/IntelOpenMP_jll.toml. Python's distribution has _not_ been flagged as vulnerable by PYSEC and my read of the upstream vulnerability documentation agrees with that.