### PR TITLE
more careful consideration of importing rejected/disputed/empty advisories

### DIFF
--- a/scripts/search_upstream_advisories.jl
+++ b/scripts/search_upstream_advisories.jl
@@ -55,7 +55,7 @@ function main()
                         (any(!SecurityAdvisories.has_upper_bound, existing.affected) && all(SecurityAdvisories.has_upper_bound, advisory.affected)) ||
                         (SecurityAdvisories.is_valid(existing) && !SecurityAdvisories.is_valid(advisory)) ||
                         (SecurityAdvisories.is_vulnerable(advisory) && !SecurityAdvisories.is_vulnerable(advisory))
-                    )) || (is_valid(advisory) && SecurityAdvisories.is_vulnerable(advisory))
+                    )) || (SecurityAdvisories.is_valid(advisory) && SecurityAdvisories.is_vulnerable(advisory))
                 end
                 # And also remove advisories that don't affect the searched package
                 filter!(advisories) do advisory

--- a/scripts/search_upstream_advisories.jl
+++ b/scripts/search_upstream_advisories.jl
@@ -21,21 +21,17 @@ function main()
     if startswith(input, "CVE") || startswith(input, "EUVD") || endswith(input, r"GHSA-\w{4}-\w{4}-\w{4}")
         push!(advisories, SecurityAdvisories.fetch_advisory(input))
         info["haystack_total"] = 1
+        # No filtering is done, no aggregating with aliases is done
     elseif !isempty(input)
         # Search for advisories matching a particular package name, both directly and through upstream matches.
-        # The direct package matches are more likely to be relevant, even if we're missing affected entries.
         aliases = SecurityAdvisories.fetch_package_matches(input)
-        # But upstream matches are only relevant if they actually apply to the package:
         upstreams = SecurityAdvisories.fetch_package_upstreams(input)
         info["haystack_total"] = length(aliases) + length(upstreams)
-        append!(advisories, aliases) # We don't filter aliases (for now, at least) because they're expected to always be relevant
-        append!(advisories, filter(SecurityAdvisories.is_vulnerable, upstreams))
-        # And also remove advisories that don't affect the searched package
+        append!(advisories, aliases)
+        append!(advisories, upstreams)
         filter!(advisories) do advisory
             input in SecurityAdvisories.vulnerable_packages(advisory)
         end
-        # And lastly, remove advisories that are known to be disputed
-        filter!(!SecurityAdvisories.is_disputed, advisories)
     else
         whole_pkg_list = shuffle(SecurityAdvisories.all_pkgs())
         pkg_search_count = 0
@@ -48,22 +44,23 @@ function main()
                 upstreams = SecurityAdvisories.fetch_package_upstreams(input)
                 info["haystack"] = "$pkg_search_count random packages"
                 info["haystack_total"] += length(aliases) + length(upstreams)
-                append!(advisories, aliases) # We don't filter aliases (for now, at least) because they're expected to always be relevant
-                append!(advisories, filter(SecurityAdvisories.is_vulnerable, upstreams))
-                # Only suggest updates to existing advisories if the existing JLSEC has an unbounded vulnerability
-                # and the new one suggests a bounded one. This reduces churn in, e.g., added references, etc.
-                # Explicitly asking for a package would add these.
+                append!(advisories, aliases)
+                append!(advisories, upstreams)
+                # We're more aggressive in filtering found advisories when doing the ecosystem walk;
+                # We'll only suggest advisories that are valid and vulnerable — and if there's already JLSECs for the same issue, we'll only suggest updates
+                # if the new advisory changes something significant (like adding an upper bound where there was none, or changing the vulnerable status)
                 filter!(advisories) do advisory
                     existing = SecurityAdvisories.find_existing_jlsec(advisory.id, vcat(advisory.upstream, advisory.aliases))
-                    isnothing(existing) || (any(!SecurityAdvisories.has_upper_bound, existing.affected) &&
-                                            all(SecurityAdvisories.has_upper_bound, advisory.affected))
+                    (!isnothing(existing) && (
+                        (any(!SecurityAdvisories.has_upper_bound, existing.affected) && all(SecurityAdvisories.has_upper_bound, advisory.affected)) ||
+                        (SecurityAdvisories.is_valid(existing) && !SecurityAdvisories.is_valid(advisory)) ||
+                        (SecurityAdvisories.is_vulnerable(advisory) && !SecurityAdvisories.is_vulnerable(advisory))
+                    )) || (is_valid(advisory) && SecurityAdvisories.is_vulnerable(advisory))
                 end
                 # And also remove advisories that don't affect the searched package
                 filter!(advisories) do advisory
                     input in SecurityAdvisories.vulnerable_packages(advisory)
                 end
-                # And lastly, remove advisories that are known to be disputed
-                filter!(!SecurityAdvisories.is_disputed, advisories)
             catch ex
                 @error "Error searching for $input" ex
                 empty!(advisories)
@@ -87,6 +84,9 @@ function main()
         existing = SecurityAdvisories.find_existing_jlsec(advisory.id, vcat(advisory.upstream, advisory.aliases))
         if !isnothing(existing)
             advisory = SecurityAdvisories.update(existing, advisory)
+        elseif !SecurityAdvisories.is_valid(advisory) || !SecurityAdvisories.is_vulnerable(advisory)
+            @warn "Advisory $(vcat(advisory.upstream, advisory.aliases)) is not valid or not vulnerable and does not have an existing JLSEC advisory, skipping publication"
+            continue
         end
         dir = mkpath(joinpath(@__DIR__, "..", "advisories", "published", string(SecurityAdvisories.year(advisory))))
         file = joinpath(dir, advisory.id * ".md")

--- a/scripts/search_upstream_advisories.jl
+++ b/scripts/search_upstream_advisories.jl
@@ -80,6 +80,7 @@ function main()
 
     # Now create or update the found advisories:
     n_modified = 0
+    results = Advisory[]
     for advisory in advisories
         existing = SecurityAdvisories.find_existing_jlsec(advisory.id, vcat(advisory.upstream, advisory.aliases))
         if !isnothing(existing)
@@ -94,6 +95,7 @@ function main()
         open(file, "w") do io
             SecurityAdvisories.print(io, advisory)
         end
+        push!(results, advisory)
     end
     n_total = length(advisories)
     n_created = n_total - n_modified
@@ -102,7 +104,7 @@ function main()
     io = open(get(ENV, "GITHUB_OUTPUT", tempname()), "a+")
     verb = n_modified > 0 && n_created == 0 ? "Update" :
            n_modified == 0 && n_created > 0 ? "Publish" : "Publish and update"
-    unique_pkgs = unique(Iterators.flatten(SecurityAdvisories.vulnerable_packages.(advisories)))
+    unique_pkgs = unique(Iterators.flatten(SecurityAdvisories.vulnerable_packages.(results)))
     pkg_str = length(unique_pkgs) <= 3 ? join(unique_pkgs, ", ", " and ") : "$(length(unique_pkgs)) packages"
     advisory_str = n_total == 1 ? "advisory" : "advisories"
     println(io, "branch=", input)
@@ -114,13 +116,13 @@ function main()
 
     divide(f, x) = return (filter(f, x), filter(!f, x))
 
-    unbounded = count(any(!SecurityAdvisories.has_upper_bound, a.affected) for a in advisories)
+    unbounded = count(any(!SecurityAdvisories.has_upper_bound, a.affected) for a in results)
     if unbounded > 0
         println(io, "### ⚠ There are $unbounded advisories with unbounded vulnerabilities")
         println(io, "The publication of unbounded advisories is significantly more impactful and, if at all possible, should be addressed in the packages directly")
     end
 
-    aliases, upstreams = divide(x->!isempty(x.aliases), advisories)
+    aliases, upstreams = divide(x->!isempty(x.aliases), results)
 
     if !isempty(aliases)
         pkgs = unique(Iterators.flatten(SecurityAdvisories.vulnerable_packages.(aliases)))

--- a/src/NVD.jl
+++ b/src/NVD.jl
@@ -305,6 +305,13 @@ function advisory(vuln)
             break # We'll just find the first such metric; there may be more
         end
     end
+    db = Dict{String, Any}()
+    if exists(vuln.cve, :vulnStatus)
+        db["status"] = vuln.cve.vulnStatus
+    end
+    if exists(vuln.cve, :cveTags)
+        db["tags"] = map(t->Dict(string(k)=>v for (k,v) in t), vuln.cve.cveTags)
+    end
 
     return Advisory(;
         id = string(PREFIX, "-0000-", vuln.cve.id),
@@ -323,7 +330,7 @@ function advisory(vuln)
             imported = Dates.now(Dates.UTC),
             url = string(NVD_API_BASE, "?cveId=", vuln.cve.id),
             html_url = string("https://nvd.nist.gov/vuln/detail/", vuln.cve.id),
-            database_specific = exists(vuln.cve, :cveTags) ? Dict("tags" => map(t->Dict(string(k)=>v for (k,v) in t), vuln.cve.cveTags)) : Dict()
+            database_specific = db,
             )]
         )
 end

--- a/src/advisory.jl
+++ b/src/advisory.jl
@@ -234,6 +234,23 @@ function is_disputed(a::Advisory)
     any(==("disputed")∘lowercase, Iterators.flatten(get(tags, "tags", []) for src in a.jlsec_sources for tags in get(src.database_specific, "tags", [])))
 end
 
+"""
+    is_rejected(advisory)
+
+Return `true` if the advisory has a status of "rejected" (currently the only source giving this information is NVD)
+"""
+function is_rejected(a::Advisory)
+    any(==("rejected")∘lowercase, (get(src, "status", "") for src in a.jlsec_sources))
+end
+
+"""
+    is_valid(advisory)
+
+Return `true` if the advisory is published and not disputed/rejected/withdrawn
+"""
+function is_valid(a::Advisory)
+    return !isnothing(a.published) && !is_disputed(a) && !is_rejected(a) && isnothing(a.withdrawn)
+end
 
 """
     update(original::Advisory, updates::Advisory)
@@ -242,13 +259,19 @@ Given an `original` advisory and some `updates`, return a new advisory with the 
 and new data from `updates`, but ignoring some metadata-like fields like import and modification dates
 """
 function update(original::Advisory, updates::Advisory)
+    newly_withdrawn = nothing
+    if (!is_valid(updates) && is_valid(original)) || (!is_vulnerable(updates) && is_vulnerable(original))
+        # Sometimes the new updates are rejected but haven't set a withdrawn date (typically from NVD)
+        # Or if the updates have _no_ vulnerable ranges at all, that should also be considered as a withdraw
+        newly_withdrawn = Dates.now(Dates.UTC)
+    end
     original ≈ updates && return original # No need to update if nothing relevant changed
     return Advisory(;
         # use whatever the default `schema_version` is
         id = original.id,
         modified = max(original.modified, updates.modified),
         published = original.published,
-        withdrawn = something(original.withdrawn, updates.withdrawn, Some(nothing)),
+        withdrawn = something(original.withdrawn, updates.withdrawn, newly_withdrawn, Some(nothing)),
         ## All other fields are directly taken from the updated advisory
         aliases = updates.aliases,
         upstream = updates.upstream,

--- a/src/advisory.jl
+++ b/src/advisory.jl
@@ -240,16 +240,16 @@ end
 Return `true` if the advisory has a status of "rejected" (currently the only source giving this information is NVD)
 """
 function is_rejected(a::Advisory)
-    any(==("rejected")∘lowercase, (get(src, "status", "") for src in a.jlsec_sources))
+    any(==("rejected")∘lowercase, (get(src.database_specific, "status", "") for src in a.jlsec_sources))
 end
 
 """
     is_valid(advisory)
 
-Return `true` if the advisory is published and not disputed/rejected/withdrawn
+Return `true` if the advisory is published by its upstream sources and not disputed/rejected/withdrawn
 """
 function is_valid(a::Advisory)
-    return !isnothing(a.published) && !is_disputed(a) && !is_rejected(a) && isnothing(a.withdrawn)
+    return all(!isnothing(src.published) for src in a.jlsec_sources) && !is_disputed(a) && !is_rejected(a) && isnothing(a.withdrawn)
 end
 
 """


### PR DESCRIPTION
This changes the search strategy significantly; instead of filtering the haystack of advisories, we are more careful to avoid _creating_ rejected/withdrawn advisories.  And if we already have a valid advisory, we should make that newly withdrawn.