### PR TITLE
prioritize searches and increase cadence to 3x/day

### DIFF
--- a/.github/workflows/search-upstream-advisories.yml
+++ b/.github/workflows/search-upstream-advisories.yml
@@ -2,8 +2,8 @@ name: Search for upstream advisories
 
 on:
   schedule:
-    # Run at 3 AM UTC every day
-    - cron: '0 3 * * *'
+    # Run every eight hours
+    - cron: '0 */8 * * *'
   workflow_dispatch:
     inputs:
       haystack:

--- a/scripts/search_upstream_advisories.jl
+++ b/scripts/search_upstream_advisories.jl
@@ -4,7 +4,6 @@ using SecurityAdvisories: SecurityAdvisories, Advisory, NVD, EUVD, GitHub, Versi
 using GeneralMetadata
 using TOML: TOML
 using Dates: Dates
-using Random: shuffle
 using DataStructures: DefaultDict, OrderedDict
 using SHA: sha256
 
@@ -33,7 +32,13 @@ function main()
             input in SecurityAdvisories.vulnerable_packages(advisory)
         end
     else
-        whole_pkg_list = shuffle(SecurityAdvisories.all_pkgs())
+        # We take a (not totally) random walk through the ecosystem, prioritizing
+        # JLLs and registrations in the last three days, avoiding packages for which we have active PRs
+        pkgdate = sort([(pkg, maximum(v->get(v, "registered", typemin(Dates.DateTime)), values(info))) for (pkg, info) in GeneralMetadata.metadata()],
+            by=x->(endswith(x[1], "jll"), (Dates.now() - x[2] < Dates.Day(3)), rand()), rev=true)
+        whole_pkg_list = first.(pkgdate) # shuffle!(collect(keys(GeneralMetadata.metadata())))
+        # We remove any pending PRs that jlsec-bot has already opened
+        filter!(!in(Set(GitHub.fetch_branches("jlsec-bot", "SecurityAdvisories.jl"))), whole_pkg_list)
         pkg_search_count = 0
         while isempty(advisories)
             (input, _) = pop!(whole_pkg_list)

--- a/scripts/search_upstream_advisories.jl
+++ b/scripts/search_upstream_advisories.jl
@@ -41,7 +41,7 @@ function main()
         filter!(!in(Set(GitHub.fetch_branches("jlsec-bot", "SecurityAdvisories.jl"))), whole_pkg_list)
         pkg_search_count = 0
         while isempty(advisories)
-            (input, _) = pop!(whole_pkg_list)
+            input = popfirst!(whole_pkg_list)
             pkg_search_count += 1
             @info "searching for $input"
             try

--- a/src/GitHub.jl
+++ b/src/GitHub.jl
@@ -219,6 +219,12 @@ function fetch_package_advisories(pkg)
     return fetch_repo_advisories(owner, chopsuffix(repo_name, ".git"))
 end
 
+function fetch_branches(owner, repo)
+    url = "$GITHUB_API_BASE/repos/$owner/$repo/branches?per_page=100"
+    vec = fetch_all_pages(url, build_headers())
+    return [b["name"] for b in vec]
+end
+
 function vendor_product_versions(advisory)
     vpv = Tuple{String,String,String}[]
     for v in get(advisory, :vulnerabilities, [])


### PR DESCRIPTION
This prioritizes seaching recently updated JLLs, while avoiding those for which we already have pending PRs. I am hoping this will find more of the easy merges for the more used packages first.