### PR TITLE
Only look for published JLSECs when searching

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -521,7 +521,7 @@ function find_existing_jlsec(id, aliases=String[]; path=joinpath(@__DIR__, "..",
     isdir(path) || return nothing
     ids = Set(Iterators.flatten(([id], aliases)))
     @info "looking for $ids in existing jlsecs"
-    for (root, _, files) in walkdir(joinpath(@__DIR__, "..", "advisories"))
+    for (root, _, files) in walkdir(path)
         for file in joinpath.(root, files)
             is_jlsec_advisory_path(file) || continue
             candidate = parsefile(file)


### PR DESCRIPTION
This may not be the complete solution here; I'm not sure what would happen if a GHSA gets published with a reserved alias... but at least this is needed for now.