### PR TITLE
Change search schedule to run once a day

### DIFF
--- a/.github/workflows/search-upstream-advisories.yml
+++ b/.github/workflows/search-upstream-advisories.yml
@@ -2,8 +2,8 @@ name: Search for upstream advisories
 
 on:
   schedule:
-    # Run every eight hours
-    - cron: '0 */8 * * *'
+    # Run once a day
+    - cron: '0 5 */1 * *'
   workflow_dispatch:
     inputs:
       haystack:


### PR DESCRIPTION
We've harvested the low-hanging fruit and recent searches have taken many hours, looking through nearly 1/10th of the entire ecosystem before finding anything relevant.  So we slow back down.