### PR TITLE
Nightly cleanup of jlsec-bot's merged fork branches

### DIFF
--- a/.github/workflows/cleanup-bot-branches.yml
+++ b/.github/workflows/cleanup-bot-branches.yml
@@ -1,0 +1,38 @@
+name: Cleanup bot branches
+
+# jlsec-bot pushes its PR branches to its fork, so the repository's
+# "automatically delete head branches" setting cannot remove them.
+# This nightly job deletes fork branches whose PRs have been merged.
+on:
+  schedule:
+    - cron: '30 6 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  delete-merged-branches:
+    name: Delete merged fork branches
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.JLSEC_BOT_TOKEN }}
+      FORK: jlsec-bot/SecurityAdvisories.jl
+      BASE: ${{ github.repository }}
+    steps:
+    - name: Delete fork branches with merged PRs
+      run: |
+        default_branch=$(gh api "repos/$FORK" --jq .default_branch)
+        gh api --paginate "repos/$FORK/branches" --jq '.[].name' | while read -r branch; do
+          if [ "$branch" = "$default_branch" ]; then
+            continue
+          fi
+          prs=$(gh api -X GET "repos/$BASE/pulls" -f head="jlsec-bot:$branch" -f state=all)
+          n_open=$(jq '[.[] | select(.state == "open")] | length' <<<"$prs")
+          n_merged=$(jq '[.[] | select(.merged_at != null)] | length' <<<"$prs")
+          if [ "$n_open" -eq 0 ] && [ "$n_merged" -gt 0 ]; then
+            echo "Deleting $branch (merged)"
+            gh api -X DELETE "repos/$FORK/git/refs/heads/$branch"
+          else
+            echo "Keeping $branch (open PRs: $n_open, merged PRs: $n_merged)"
+          fi
+        done

--- a/.github/workflows/cleanup-bot-branches.yml
+++ b/.github/workflows/cleanup-bot-branches.yml
@@ -2,7 +2,8 @@ name: Cleanup bot branches
 
 # jlsec-bot pushes its PR branches to its fork, so the repository's
 # "automatically delete head branches" setting cannot remove them.
-# This nightly job deletes fork branches whose PRs have been merged.
+# This nightly job deletes fork branches whose PRs have all been
+# merged or closed.
 on:
   schedule:
     - cron: '30 6 * * *'
@@ -27,12 +28,12 @@ jobs:
             continue
           fi
           prs=$(gh api -X GET "repos/$BASE/pulls" -f head="jlsec-bot:$branch" -f state=all)
+          n_total=$(jq 'length' <<<"$prs")
           n_open=$(jq '[.[] | select(.state == "open")] | length' <<<"$prs")
-          n_merged=$(jq '[.[] | select(.merged_at != null)] | length' <<<"$prs")
-          if [ "$n_open" -eq 0 ] && [ "$n_merged" -gt 0 ]; then
-            echo "Deleting $branch (merged)"
+          if [ "$n_open" -eq 0 ] && [ "$n_total" -gt 0 ]; then
+            echo "Deleting $branch (all $n_total PRs merged or closed)"
             gh api -X DELETE "repos/$FORK/git/refs/heads/$branch"
           else
-            echo "Keeping $branch (open PRs: $n_open, merged PRs: $n_merged)"
+            echo "Keeping $branch (open PRs: $n_open, total PRs: $n_total)"
           fi
         done


### PR DESCRIPTION
## What

Adds a scheduled workflow (nightly at 6:30 UTC, plus manual `workflow_dispatch`) that deletes branches on the `jlsec-bot/SecurityAdvisories.jl` fork once their PRs into this repository have been merged or closed.

## Why

jlsec-bot pushes its PR branches to its fork (`push-to-fork` in the advisory search workflow), so the repository's "automatically delete head branches" setting never cleans them up, and they accumulate indefinitely.

## How it works

For each branch on the fork, the job queries this repo's PRs with head `jlsec-bot:<branch>` and deletes the branch only if it has at least one PR and none of them are open — merged and closed-without-merging both count as done. It keeps the fork's default branch, branches with open PRs, and branches with no PRs at all. The first run will sweep the existing backlog.

## Notes for reviewers

- A cron job was chosen deliberately over a `pull_request_target: closed` trigger to avoid that event's security footguns; this workflow runs with no PR-event context at all.
- The workflow sets `permissions: {}`; the only credential used is `JLSEC_BOT_TOKEN` (for both the read queries and the deletions), which already has push access to the fork.
- Cron is offset from the 5:00 UTC advisory search to avoid overlapping with branch creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)