### PR TITLE
Add dependabot support for gh actions and pin action plugins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -18,15 +18,15 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ inputs.ref || github.sha }}
 
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2.7.0
         with:
           version: '1'
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
 
@@ -57,10 +57,10 @@ jobs:
         run: npx pagefind --site web/__site
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: web/__site
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -29,13 +29,13 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: julia-actions/setup-julia@4c0cb0fce8556fdb04a90347310e5db8b1f98fb9 # v2.7.0
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v2
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/cache@d10a6fd8f31b12404a54613ebad242900567f2b9 # v2.1.0
+      - uses: julia-actions/julia-buildpkg@e3eb439fad4f9aba7da2667e7510e4a46ebc46e1 # v1.7.0
+      - uses: julia-actions/julia-runtest@6e050c8013b833b1195105ff2fce9cd802f53271 # v1.12.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/search-upstream-advisories.yml
+++ b/.github/workflows/search-upstream-advisories.yml
@@ -29,12 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Setup Julia
-      uses: julia-actions/setup-julia@v1
+      uses: julia-actions/setup-julia@ac0d62164df5a47de404f4e96ce86a1a28a28d56 # v1.9.6
 
     - name: Install Julia dependencies
       run: |
@@ -57,7 +57,7 @@ jobs:
 
     - name: Create Pull Request
       if: steps.git-check.outputs.changes == 'true'
-      uses: peter-evans/create-pull-request@v7
+      uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
       with:
         token: ${{ secrets.JLSEC_BOT_TOKEN }}
         committer: JLSEC[bot] <234068973+jlsec-bot@users.noreply.github.com>

--- a/.github/workflows/update-and-export.yml
+++ b/.github/workflows/update-and-export.yml
@@ -25,20 +25,20 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         fetch-depth: 0
 
     - name: Setup Julia
-      uses: julia-actions/setup-julia@v1
+      uses: julia-actions/setup-julia@ac0d62164df5a47de404f4e96ce86a1a28a28d56 # v1.9.6
 
     - name: Install Julia dependencies
       run: |
         julia --project=. -e 'using Pkg; Pkg.instantiate()'
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
         go-version: 'stable'
 


### PR DESCRIPTION
Claude wrote a script to pin and verify these, it all looks reasonable:

```
▶ grep -hoE 'uses: [^ ]+@[0-9a-f]{40} # v[0-9.]+' *.yml | sort -u | while read -r _ ref _ ver; do
  repo=${ref%@*}; sha=${ref#*@}
  remote=$(git ls-remote --tags "https://github.com/$repo" "refs/tags/$ver" "refs/tags/$ver^{}" | tail -1 | cut -f1)
  if [ "$remote" = "$sha" ]; then echo "OK   $repo@$ver"; else echo "FAIL $repo@$ver: pinned=$sha remote=$remote"; fi
done
OK   actions/checkout@v4.3.1
OK   actions/deploy-pages@v4.0.5
OK   actions/setup-go@v5.6.0
OK   actions/setup-node@v4.4.0
OK   actions/upload-pages-artifact@v3.0.1
OK   julia-actions/cache@v2.1.0
OK   julia-actions/julia-buildpkg@v1.7.0
OK   julia-actions/julia-runtest@v1.12.0
OK   julia-actions/setup-julia@v2.7.0
OK   julia-actions/setup-julia@v1.9.6
OK   peter-evans/create-pull-request@v7.0.11
OK   shravanngoswamii/html-link-action@v1.1.0
```