### PR TITLE
OSV schema v1.8.0: support generating, storing, and exporting severity sources

### DIFF
--- a/src/EUVD.jl
+++ b/src/EUVD.jl
@@ -175,7 +175,7 @@ function advisory(vuln)
         # related -- nothing structured
         details = get(vuln, :description, nothing),
         severity = if exists(vuln, :baseScoreVector) && exists(vuln, :baseScoreVersion)
-                Severity[Severity(type = "CVSS_V"*vuln.baseScoreVersion[1], score = string(vuln.baseScoreVector))]
+                Severity[Severity(type = "CVSS_V"*vuln.baseScoreVersion[1], score = string(vuln.baseScoreVector), source = "EUVD")]
             else
                 Severity[]
             end,

--- a/src/GitHub.jl
+++ b/src/GitHub.jl
@@ -260,13 +260,13 @@ function advisory(vuln)
     # GitHub stores severities all over the place
     severities = Severity[]
     if exists(vuln, :cvss_severities, :cvss_v3, :vector_string)
-        push!(severities, Severity("CVSS_V3", vuln.cvss_severities.cvss_v3.vector_string))
+        push!(severities, Severity("CVSS_V3", vuln.cvss_severities.cvss_v3.vector_string, "GHSA"))
     end
     if exists(vuln, :cvss_severities, :cvss_v4, :vector_string)
-        push!(severities, Severity("CVSS_V4", vuln.cvss_severities.cvss_v4.vector_string))
+        push!(severities, Severity("CVSS_V4", vuln.cvss_severities.cvss_v4.vector_string, "GHSA"))
     end
     if exists(vuln, :cvss, :vector_string)
-        push!(severities, Severity(vuln.cvss.vector_string))
+        push!(severities, Severity(vuln.cvss.vector_string; source = "GHSA"))
     end
     unique!(x->x.type, severities)
 

--- a/src/NVD.jl
+++ b/src/NVD.jl
@@ -296,13 +296,14 @@ function advisory(vuln)
     for (version, metrics) in pairs(get(vuln.cve, :metrics, Dict()))
         v = match(r"^cvssMetricV([234])", string(version))
         isnothing(v) && continue
-        for metric in metrics
+        for metric in sort(metrics, by=x->(x.source != "nvd@nist.gov", x.type != "Primary"))
             exists(metric, :cvssData, :vectorString) || continue
             push!(severities, Severity(
                 type = "CVSS_V"*v[1],
-                score = string(metric.cvssData.vectorString)
+                score = string(metric.cvssData.vectorString),
+                source = metric.source == "nvd@nist.gov" ? "NVD" : "CNA"
             ))
-            break # We'll just find the first such metric; there may be more
+            break # Only grab one of each type, preferring NVD's assessment over CNA
         end
     end
     db = Dict{String, Any}()

--- a/src/advisory.jl
+++ b/src/advisory.jl
@@ -291,6 +291,22 @@ function fetch_updates(original::Advisory; reset_fields = Symbol[])
 end
 
 """
+    combine_severities(a, b)
+
+Combine two lists of `Severity`s, keeping only one of each `type`: the first source to claim a
+type wins, but later values from that same source are updated assessments and replace it.
+"""
+function combine_severities(a::Vector{Severity}, b::Vector{Severity})
+    result = OrderedDict{String, Severity}(sev.type => sev for sev in a)
+    for sev in b
+        if get(result, sev.type, sev).source == sev.source
+            result[sev.type] = sev
+        end
+    end
+    return collect(values(result))
+end
+
+"""
     combine(a::Advisory, b::Advisory)
 
 Take two advisories and combine their information, preferring the first argument when it is unclear which is better
@@ -338,8 +354,7 @@ function combine(a::Advisory, b::Advisory)
         summary = something(a.summary, b.summary, Some(nothing)),
         # Generally the longer details are better, but we could try to find some Markdown?
         details = length(a.details) >= length(b.details) ? a.details : b.details,
-        # Only keep one severity of each type, preferring the first argument's if both exist
-        severity = unique!(s->s.type, vcat(a.severity, b.severity)),
+        severity = combine_severities(a.severity, b.severity),
         # Affected is the trickiest one when both exist; we want the "best" information here
         affected = if !isnothing(a.affected) && !isnothing(b.affected)
             pkgs = union((entry.pkg for entry in a.affected), (entry.pkg for entry in b.affected))

--- a/src/advisory.jl
+++ b/src/advisory.jl
@@ -427,7 +427,7 @@ function to_toml_frontmatter_collection(s::Severity, xs)
     if all(x isa Severity && x == tryparse(Severity, x.score) for x in xs)
         return s.score
     else
-        return OrderedDict(string(f) => to_toml_frontmatter(getproperty(s, f)) for f in fieldnames(Severity))
+        return OrderedDict(string(f) => to_toml_frontmatter(getproperty(s, f)) for f in fieldnames(Severity) if is_populated(getfield(s, f)))
     end
 end
 to_toml_frontmatter(c::Credit) = to_toml_frontmatter_collection(c, [c])

--- a/src/advisory.jl
+++ b/src/advisory.jl
@@ -159,7 +159,7 @@ There is just one place where we differ:
 """
 @kwdef mutable struct Advisory
     ## OSV fields
-    schema_version::String = "1.7.4"
+    schema_version::String = "1.8.0"
     # The identifier and dates are re-written by GitHub Actions upon publication and modification
     id::String = string(PREFIX, "-0000-", string(Dates.datetime2epochms(Dates.now()), base=36), "-", string(rand(UInt32), base=36))
     modified::DateTime = Dates.now(Dates.UTC)
@@ -523,9 +523,13 @@ to_osv_dict(x::Union{AbstractString, Integer, AbstractFloat, Bool}) = x
 to_osv_dict(d::AbstractDict) = OrderedDict(string(k)=>to_osv_dict(v) for (k,v) in d)
 to_osv_dict(A::AbstractArray) = [to_osv_dict(v) for v in A]
 function to_osv_dict(a::Severity)
-    # We still export with OSV-schema v1.7, which does not include the `source` field, so we omit it here
-    # We plan to include it if/when it supports the values we use in the JLSEC database (cf. https://github.com/ossf/osv-schema/issues/581)
-    return OrderedDict(string(f) => to_osv_dict(getproperty(a, f)) for f in fieldnames(typeof(a)) if is_populated(getproperty(a, f)) && f != :source)
+    # OSV-schema v1.8.0 only supports `source` values of "NVD", "CNA" or "SELF" (or missing). We also import advisories from EUVD and GitHub,
+    # and if those have severities that NVD doesn't, we record those as sources too. So only include the source if it's one of the three that OSV supports.
+    d = OrderedDict("type" => a.type, "score" => a.score)
+    if a.source in ("NVD", "CNA", "SELF")
+        d["source"] = a.source
+    end
+    return d
 end
 function to_osv_dict(a::Union{Reference, Credit, AdvisorySource})
     return OrderedDict(string(f) => to_osv_dict(getproperty(a, f)) for f in fieldnames(typeof(a)) if is_populated(getproperty(a, f)))

--- a/src/advisory.jl
+++ b/src/advisory.jl
@@ -103,12 +103,14 @@ Represent a CVSS severity. If no type is given, CVSS_V2/3/4 are auto-detected.
 @kwdef struct Severity
     type::String
     score::String
+    source::Union{Nothing, String} = nothing
 end
-function Severity(score)
+function Severity(score; source = nothing)
     s = tryparse(Severity, score)
     isnothing(s) && throw(ArgumentError("cannot parse severity score $score"))
-    return s
+    return Severity(s.type, s.score, source)
 end
+Severity(type, score; source = nothing) = Severity(type, score, source)
 Base.convert(::Type{Severity}, s::AbstractString) = Severity(s)
 Base.convert(::Type{Severity}, d::AbstractDict) = Severity(; Dict(Symbol(k)=>v for (k,v) in d)...)
 function Base.tryparse(::Type{Severity}, score)
@@ -336,7 +338,8 @@ function combine(a::Advisory, b::Advisory)
         summary = something(a.summary, b.summary, Some(nothing)),
         # Generally the longer details are better, but we could try to find some Markdown?
         details = length(a.details) >= length(b.details) ? a.details : b.details,
-        severity = union(a.severity, b.severity),
+        # Only keep one severity of each type, preferring the first argument's if both exist
+        severity = unique!(s->s.type, vcat(a.severity, b.severity)),
         # Affected is the trickiest one when both exist; we want the "best" information here
         affected = if !isnothing(a.affected) && !isnothing(b.affected)
             pkgs = union((entry.pkg for entry in a.affected), (entry.pkg for entry in b.affected))
@@ -519,7 +522,12 @@ to_osv_dict(x::Dates.DateTime) = chopsuffix(string(x), "Z") * "Z" # All times sh
 to_osv_dict(x::Union{AbstractString, Integer, AbstractFloat, Bool}) = x
 to_osv_dict(d::AbstractDict) = OrderedDict(string(k)=>to_osv_dict(v) for (k,v) in d)
 to_osv_dict(A::AbstractArray) = [to_osv_dict(v) for v in A]
-function to_osv_dict(a::Union{Severity, Reference, Credit, AdvisorySource})
+function to_osv_dict(a::Severity)
+    # We still export with OSV-schema v1.7, which does not include the `source` field, so we omit it here
+    # We plan to include it if/when it supports the values we use in the JLSEC database (cf. https://github.com/ossf/osv-schema/issues/581)
+    return OrderedDict(string(f) => to_osv_dict(getproperty(a, f)) for f in fieldnames(typeof(a)) if is_populated(getproperty(a, f)) && f != :source)
+end
+function to_osv_dict(a::Union{Reference, Credit, AdvisorySource})
     return OrderedDict(string(f) => to_osv_dict(getproperty(a, f)) for f in fieldnames(typeof(a)) if is_populated(getproperty(a, f)))
 end
 function to_osv_dict(a::Advisory)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -134,6 +134,26 @@ end
     @test_throws "no UUID" SecurityAdvisories.purl("ThisPackageDoesHopefullyNotExist")
 end
 
+@testset "combining severities" begin
+    using SecurityAdvisories: Severity, combine_severities
+    v3_nvd = Severity("CVSS_V3", "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", "NVD")
+    v3_nvd_revised = Severity("CVSS_V3", "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L", "NVD")
+    v3_ghsa = Severity("CVSS_V3", "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H", "GHSA")
+    v3_unsourced = Severity("CVSS_V3", "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H")
+    v3_unsourced_revised = Severity("CVSS_V3", "CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H")
+    v4_ghsa = Severity("CVSS_V4", "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:N/SC:N/SI:N/SA:N", "GHSA")
+    # New types are appended
+    @test combine_severities([v3_nvd], [v4_ghsa]) == [v3_nvd, v4_ghsa]
+    # Same type from a different source: the first argument wins
+    @test combine_severities([v3_nvd], [v3_ghsa]) == [v3_nvd]
+    # Same type from the same source: it's an updated assessment, so the new value wins
+    @test combine_severities([v3_nvd], [v3_nvd_revised]) == [v3_nvd_revised]
+    # Sources must match exactly; sourceless severities only match other sourceless ones
+    @test combine_severities([v3_unsourced], [v3_nvd]) == [v3_unsourced]
+    @test combine_severities([v3_nvd], [v3_unsourced]) == [v3_nvd]
+    @test combine_severities([v3_unsourced], [v3_unsourced_revised]) == [v3_unsourced_revised]
+end
+
 @testset "fetch_combinations tolerates aliases that can't be fetched" begin
     # GHSA/EUVD/NVD advisories can reference aliases (e.g. PYSEC-*) that `fetch_advisory`
     # doesn't know how to fetch; those should be dropped from `sources` but still retained as alias ids


### PR DESCRIPTION
So I realized that #567 was actually preventing NVD severity imports as well. This is why we've been missing severities on so many of our advisories!  So since we're going to be importing lots more severities, it makes sense to start logging their provenance... and this is great timing as last week OSV-schema released version 1.8.0, which supports a `source` field.

One caveat here is that neither EUVD nor GHSA advisories report the provenance of _their_ severities.  The NVD does, however.  And in practice, 99.9% of their advisories are "shadowed" by our preference for NVD data, so this isn't a major issue.

This pull request bumps the version of newly-written and newly-updated JLSECs to v1.8.0.  It adds support for severity sources, in the Julia `struct Severity`, the toml parser/writer, and the osv writer.