### PR TITLE
enable re-searching JLSECs themselves

### DIFF
--- a/scripts/search_upstream_advisories.jl
+++ b/scripts/search_upstream_advisories.jl
@@ -17,7 +17,7 @@ function main(input = get(ARGS, 1, ""), filter_results = lowercase(get(ARGS, 2, 
     advisories = Advisory[]
     info = Dict{String,Any}()
     info["haystack"] = input
-    if startswith(input, "CVE") || startswith(input, "EUVD") || endswith(input, r"GHSA-\w{4}-\w{4}-\w{4}")
+    if startswith(input, "JLSEC") || startswith(input, "CVE") || startswith(input, "EUVD") || endswith(input, r"GHSA-\w{4}-\w{4}-\w{4}")
         append!(advisories, SecurityAdvisories.fetch_combinations([SecurityAdvisories.fetch_advisory(input)]))
     elseif !isempty(input) && !any(isspace_or_comma, input)
         @info "searching for $input"

--- a/src/advisory.jl
+++ b/src/advisory.jl
@@ -222,6 +222,21 @@ function vuln_id(a::Advisory)
 end
 
 """
+    srcid(a::Advisory)
+
+Return the source ID of an advisory; either a published JLSEC ID or the only imported source ID
+"""
+function srcid(a::Advisory)
+    if startswith(a.id, string(PREFIX, "-2"))
+        return a.id
+    elseif length(a.jlsec_sources) == 1
+        return srcid(a.jlsec_sources[1])
+    else
+        error("cannot determine source ID for advisory with multiple sources and no published JLSEC ID")
+    end
+end
+
+"""
     function preferred_id(collection_of_ids)
 
 Given a collection of vulnerability IDs, return the "best" one

--- a/src/common.jl
+++ b/src/common.jl
@@ -517,7 +517,7 @@ Given an advisory id and an (optional) list of its own aliases, return the publi
 JLSEC advisory corresponding to it or nothing none correspond.
 """
 function find_existing_jlsec(id, aliases=String[]; path=joinpath(@__DIR__, "..", "advisories", "published"))
-    startswith(id, string(PREFIX, "-2")) && return id # lol y3k problems
+    startswith(id, string(PREFIX, "-2")) && return fetch_advisory(id) # lol y3k problems
     isdir(path) || return nothing
     ids = Set(Iterators.flatten(([id], aliases)))
     @info "looking for $ids in existing jlsecs"
@@ -649,7 +649,7 @@ This is valuable because some databases are better at searching (e.g., EUVD), wh
 """
 function fetch_combinations(batch)
     # These advisories haven't been combined yet, so they only have one source
-    sources = Dict{String, Advisory}(a.jlsec_sources[].id => a for a in batch)
+    sources = Dict{String, Advisory}(srcid(a) => a for a in batch)
 
     # First gather all IDs referenced by the advisories in the batch and add missing ones
     known_ids = Set{String}(Iterators.flatten((Iterators.flatten(a.aliases for a in batch), Iterators.flatten(a.upstream for a in batch))))


### PR DESCRIPTION
This will allow us to pick up data from aliases that we already know about without clobbering the existing data