### PR TITLE
Request Yggdrasil recipe updates for unbounded JLLs with known upstream fixes

### DIFF
--- a/.github/workflows/search-upstream-advisories.yml
+++ b/.github/workflows/search-upstream-advisories.yml
@@ -65,3 +65,21 @@ jobs:
         title: ${{ steps.identify.outputs.title }}
         body: ${{ steps.identify.outputs.body }}
         branch: ${{ steps.identify.outputs.branch }}
+
+    - name: Request JLL recipe updates
+      # Unbounded JLLs whose upstream fix version is known just need a new build;
+      # ask Urdarbrunnr to open the corresponding Yggdrasil recipe update PRs
+      if: >-
+        steps.git-check.outputs.changes == 'true' &&
+        steps.identify.outputs.recipe_updates != '' &&
+        steps.identify.outputs.recipe_updates != '[]'
+      env:
+        GH_TOKEN: ${{ secrets.JLSEC_BOT_TOKEN }}
+        RECIPE_UPDATES: ${{ steps.identify.outputs.recipe_updates }}
+      run: |
+        jq -c '.[]' <<< "$RECIPE_UPDATES" | while read -r update; do
+          name=$(jq -r '.name' <<< "$update")
+          version=$(jq -r '.version' <<< "$update")
+          echo "Requesting a recipe update for $name to v$version"
+          gh workflow run update-recipe.yml --repo mbauman/Urdarbrunnr -f name="$name" -f version="$version"
+        done

--- a/scripts/search_upstream_advisories.jl
+++ b/scripts/search_upstream_advisories.jl
@@ -2,6 +2,7 @@
 # database: GitHub's GHSA, NIST/NVD's CVE, or ESINA's EUVD.
 using SecurityAdvisories: SecurityAdvisories, Advisory, NVD, EUVD, GitHub, VersionRange, package_components, PREFIX
 using GeneralMetadata
+using JSON3: JSON3
 using TOML: TOML
 using Dates: Dates
 using DataStructures: DefaultDict, OrderedDict
@@ -83,6 +84,13 @@ function main(input = get(ARGS, 1, ""), filter_results = lowercase(get(ARGS, 2, 
     n_total = length(advisories)
     n_created = n_total - n_modified
 
+    # Identify unbounded JLLs whose upstream fix is known but not yet built; these
+    # are actionable via an Yggdrasil recipe update (requested in a workflow step)
+    recipe_updates = Dict{String, SecurityAdvisories.VersionString}()
+    for adv in results, (name, version) in SecurityAdvisories.recipe_update_candidates(adv)
+        recipe_updates[name] = max(get(recipe_updates, name, version), version)
+    end
+
     # Nice logging information for the possible pull request
     io = open(get(ENV, "GITHUB_OUTPUT", tempname()), "a+")
     verb = n_modified > 0 && n_created == 0 ? "Update" :
@@ -92,6 +100,7 @@ function main(input = get(ARGS, 1, ""), filter_results = lowercase(get(ARGS, 2, 
     advisory_str = n_total == 1 ? "advisory" : "advisories"
     println(io, "branch=", input)
     println(io, "title=[automatic] $verb $n_total $advisory_str for $pkg_str")
+    println(io, "recipe_updates=", JSON3.write([Dict("name"=>name, "version"=>string(version)) for (name, version) in sort!(collect(recipe_updates))]))
     println(io, "body<<BODY_EOF")
     println(io, "This action searched `", info["haystack"], "` for advisories that pertain here. ",
         "It identified ", n_total, " ", advisory_str, " as being related to the Julia package(s): ", join("**" .* unique_pkgs .* "**", ", ", ", and "), ".")
@@ -103,6 +112,16 @@ function main(input = get(ARGS, 1, ""), filter_results = lowercase(get(ARGS, 2, 
     if unbounded > 0
         println(io, "### ⚠ There are $unbounded advisories with unbounded vulnerabilities")
         println(io, "The publication of unbounded advisories is significantly more impactful and, if at all possible, should be addressed in the packages directly")
+    end
+
+    if !isempty(recipe_updates)
+        println(io, "### 🔧 Requesting JLL recipe updates")
+        println(io, "These JLL packages are unbounded, but their upstream projects have known fixed versions that have not yet been built. ",
+            "`@jlsec-bot` has requested [recipe updates](https://github.com/mbauman/Urdarbrunnr/actions/workflows/update-recipe.yml) for:")
+        for (name, version) in sort!(collect(recipe_updates))
+            println(io, "* **", name, "_jll**: updating the `", name, "` recipe to v", version)
+        end
+        println(io)
     end
 
     aliases, upstreams = divide(x->!isempty(x.aliases), results)

--- a/src/advisory.jl
+++ b/src/advisory.jl
@@ -239,6 +239,30 @@ is_vulnerable(a::Advisory) = any(is_vulnerable, a.affected)
 vulnerable_packages(a::Advisory) = [entry.pkg for entry in a.affected if is_vulnerable(entry)]
 
 """
+    recipe_update_candidates(advisory)
+
+Return `name => version` pairs describing Yggdrasil recipe updates that could resolve
+unbounded JLL vulnerabilities in the given advisory: cases where a vulnerable `_jll`
+package has no known fixed version, yet every upstream range has an exclusive upper
+bound — meaning the upstream project has published a fixed version that simply hasn't
+been built into a JLL release yet. The `name` is the Yggdrasil recipe name (the package
+name without its `_jll` suffix) and the version is the largest upstream fixed version
+as a [`VersionString`](@ref).
+"""
+function recipe_update_candidates(a::Advisory)
+    candidates = Pair{String, VersionString}[]
+    for vuln in a.affected
+        endswith(vuln.pkg, "_jll") && is_vulnerable(vuln) && !has_upper_bound(vuln) || continue
+        is_populated(vuln.source_mapping) || continue
+        upstream_ranges = [tryparse(VersionRange, String(v)) for vmap in values(vuln.source_mapping) for v in keys(vmap)]
+        (!isempty(upstream_ranges) && all(!isnothing, upstream_ranges)) || continue
+        all(r -> has_upper_bound(r) && !r.ubinclusive, upstream_ranges) || continue
+        push!(candidates, chopsuffix(vuln.pkg, "_jll") => maximum(r -> r.ub, upstream_ranges))
+    end
+    return unique!(candidates)
+end
+
+"""
     is_disputed(advisory)
 
 Return `true` if the advisory has been tagged as disputed (currently the only source giving this information is NVD)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -166,6 +166,39 @@ end
     @test "PYSEC-2026-575" in only(combined).aliases
 end
 
+using SecurityAdvisories: Advisory, PackageVulnerability, VersionString, recipe_update_candidates
+using DataStructures: OrderedDict
+@testset "recipe update candidates" begin
+    unbounded = [VR{VersionNumber}(">= 1.0.0")]
+    bounded = [VR{VersionNumber}(">= 1.0.0, < 2.0.0")]
+    mapping(versions...) = Dict("vendor:product" => OrderedDict(v => [VR{VersionNumber}("*")] for v in versions))
+    jll(; kw...) = Advisory(affected=[PackageVulnerability(; pkg="Zstd_jll", ranges=unbounded, source_type="upstream", kw...)])
+
+    # An unbounded JLL whose upstream fix version is known (an exclusive upper bound) is actionable
+    @test recipe_update_candidates(jll(source_mapping=mapping("< 1.5.7"))) == ["Zstd" => VersionString("1.5.7")]
+    # ... using the largest fixed version across ranges, even non-semver-ish ones
+    @test recipe_update_candidates(jll(source_mapping=mapping(">= 1.0.0, < 1.4.0", "< 1.5.7"))) == ["Zstd" => VersionString("1.5.7")]
+    @test recipe_update_candidates(jll(source_mapping=mapping("< 4.3.2p2", "< 4.3.2p10"))) == ["Zstd" => VersionString("4.3.2p10")]
+
+    # But not when any upstream range is inclusively bounded, unbounded, exact, or unparseable
+    @test isempty(recipe_update_candidates(jll(source_mapping=mapping("<= 1.5.7"))))
+    @test isempty(recipe_update_candidates(jll(source_mapping=mapping("< 1.5.7", "<= 1.5.7"))))
+    @test isempty(recipe_update_candidates(jll(source_mapping=mapping("*"))))
+    @test isempty(recipe_update_candidates(jll(source_mapping=mapping("= 1.5.7"))))
+    @test isempty(recipe_update_candidates(jll(source_mapping=mapping("who knows"))))
+    # Nor without any upstream version information at all
+    @test isempty(recipe_update_candidates(jll()))
+    @test isempty(recipe_update_candidates(jll(source_mapping=Dict{String,Any}())))
+
+    # Only vulnerable-and-unbounded JLL packages are considered
+    @test isempty(recipe_update_candidates(Advisory(affected=[
+        PackageVulnerability(pkg="Zstd_jll", ranges=bounded, source_type="upstream", source_mapping=mapping("< 1.5.7"))])))
+    @test isempty(recipe_update_candidates(Advisory(affected=[
+        PackageVulnerability(pkg="Zstd_jll", ranges=VR{VersionNumber}[], source_type="upstream", source_mapping=mapping("< 1.5.7"))])))
+    @test isempty(recipe_update_candidates(Advisory(affected=[
+        PackageVulnerability(pkg="NotAJLL", ranges=unbounded, source_type="upstream", source_mapping=mapping("< 1.5.7"))])))
+end
+
 using JSON3: JSON3
 @testset "sometimes EUVD has no description" begin
     vuln = JSON3.read(joinpath(@__DIR__, "EUVD-2025-32379.json"))


### PR DESCRIPTION
## What

When the upstream advisory search finds a vulnerable `_jll` package whose Julia version range is *unbounded*, but every upstream range has an *exclusive* upper bound — i.e., the upstream project has published a fixed version that simply hasn't been built into a JLL release yet — `@jlsec-bot` now dispatches [Urdarbrunnr's `update-recipe.yml` workflow](https://github.com/mbauman/Urdarbrunnr/blob/main/.github/workflows/update-recipe.yml) with the Yggdrasil recipe name and the fixed version, kicking off the recipe update that would let the advisory become bounded.

## How

* **`src/advisory.jl`**: new `recipe_update_candidates(advisory)` returns `name => version` pairs from the unserialized `source_mapping` metadata. A candidate requires:
  * a vulnerable `_jll` package whose ranges are not all upper-bounded,
  * every upstream range parses and has an **exclusive** upper bound (`< X` means X is the fix; `<= X`, `= X`, `*`, or unparseable strings mean the fixed version isn't actually known, so nothing is dispatched).

  The recipe name is the package name without its `_jll` suffix, and the version is the largest upper bound (handled as a `VersionString`, so non-semver versions like `4.3.2p10` work).
* **`scripts/search_upstream_advisories.jl`**: collects candidates across all found advisories (deduplicating by recipe, keeping the max version), emits them as a `recipe_updates` JSON step output, and documents them in a "🔧 Requesting JLL recipe updates" section of the generated PR body.
* **`.github/workflows/search-upstream-advisories.yml`**: a new step after PR creation loops over that JSON and runs `gh workflow run update-recipe.yml --repo mbauman/Urdarbrunnr` for each, authenticated with `JLSEC_BOT_TOKEN`.

## Reviewer notes

* ⚠️ **Deployment prerequisite**: `JLSEC_BOT_TOKEN` must be able to dispatch workflows on `mbauman/Urdarbrunnr` — jlsec-bot needs write access there and the PAT needs `actions: write` scope for that repository. Otherwise the new step fails with a 403/404 (after the advisory PR has already been created).
* `fetch-updates.yml` also creates advisory PRs but is not wired up here; its plumbing only returns a count of updated advisories, so surfacing candidates there would need a small refactor. Can follow up if desired.
* New testset covers the positive path, max-version selection, non-semver versions, and each rejection reason; the full suite passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)