### PR TITLE
pass context for norn-bot to come back to us

### DIFF
--- a/.github/workflows/search-upstream-advisories.yml
+++ b/.github/workflows/search-upstream-advisories.yml
@@ -56,6 +56,7 @@ jobs:
         [[ $(git ls-files --others --modified --exclude-standard) ]] && echo "changes=true" >> $GITHUB_OUTPUT || echo "no changes"
 
     - name: Create Pull Request
+      id: create_pull_request
       if: steps.git-check.outputs.changes == 'true'
       uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
       with:
@@ -76,10 +77,11 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.JLSEC_BOT_TOKEN }}
         RECIPE_UPDATES: ${{ steps.identify.outputs.recipe_updates }}
+        PULL_REQUEST_URL: ${{ steps.create_pull_request.outputs.pull_request_url }}
       run: |
         jq -c '.[]' <<< "$RECIPE_UPDATES" | while read -r update; do
           name=$(jq -r '.name' <<< "$update")
           version=$(jq -r '.version' <<< "$update")
           echo "Requesting a recipe update for $name to v$version"
-          gh workflow run update-recipe.yml --repo mbauman/Urdarbrunnr -f name="$name" -f version="$version"
+          gh workflow run update-recipe.yml --repo mbauman/Urdarbrunnr -f name="$name" -f version="$version" -f context="${PULL_REQUEST_URL}"
         done

--- a/scripts/search_upstream_advisories.jl
+++ b/scripts/search_upstream_advisories.jl
@@ -114,16 +114,6 @@ function main(input = get(ARGS, 1, ""), filter_results = lowercase(get(ARGS, 2, 
         println(io, "The publication of unbounded advisories is significantly more impactful and, if at all possible, should be addressed in the packages directly")
     end
 
-    if !isempty(recipe_updates)
-        println(io, "### 🔧 Requesting JLL recipe updates")
-        println(io, "These JLL packages are unbounded, but their upstream projects have known fixed versions that have not yet been built. ",
-            "`@jlsec-bot` has requested [recipe updates](https://github.com/mbauman/Urdarbrunnr/actions/workflows/update-recipe.yml) for:")
-        for (name, version) in sort!(collect(recipe_updates))
-            println(io, "* **", name, "_jll**: updating the `", name, "` recipe to v", version)
-        end
-        println(io)
-    end
-
     aliases, upstreams = divide(x->!isempty(x.aliases), results)
 
     if !isempty(aliases)


### PR DESCRIPTION
We don't need to clutter the PR body with the _chance_ that the norn-bot is successful.  Rather, we give the norn-bot enough context to come back to us and report if it was able to create a pull request.