### PR TITLE
Fix fetch_combinations for repository GHSAs

### DIFF
--- a/src/advisory.jl
+++ b/src/advisory.jl
@@ -151,6 +151,16 @@ function srcid(src::AdvisorySource)
 end
 
 """
+    unscoped_id(id)
+
+Return the plain advisory id, dropping the `owner/repo/` prefix that scopes repository GHSAs
+"""
+function unscoped_id(id)
+    m = match(r"(GHSA-\w{4}-\w{4}-\w{4})$", id)
+    return isnothing(m) ? id : String(m.captures[1])
+end
+
+"""
     Advisory(; osv_kwargs...)
 
 Represent an advisory using OSV schema's definitions for nearly all its fields.

--- a/src/common.jl
+++ b/src/common.jl
@@ -655,7 +655,7 @@ function fetch_combinations(batch)
     known_ids = Set{String}(Iterators.flatten((Iterators.flatten(a.aliases for a in batch), Iterators.flatten(a.upstream for a in batch))))
     while !isempty(known_ids)
         id = pop!(known_ids)
-        if !haskey(sources, id)
+        if !any(k -> unscoped_id(k) == unscoped_id(id), keys(sources))
             try
                 # This may fail, most notably if we got a repository GHSA that's not in the global GHSA DB
                 # or an ID from a database that we don't yet support fetching from. That's ok; it'll still appear
@@ -694,8 +694,14 @@ function fetch_combinations(batch)
     advisories = Advisory[]
     for alias_set in alias_sets
         # Now combine the advisories within each alias set into a single advisory in our preferred order
-        # Note that we may not have fetched an advisory for all the aliases
-        ids = sort(collect(intersect(alias_set, keys(sources))), by=preferred_id_sort)
+        # Note that we may not have fetched an advisory for all the aliases, and that repo-scoped
+        # source ids (owner/repo/GHSA-xxxx) match their plain GHSA aliases
+        ids = sort(filter(id -> any(a -> unscoped_id(a) == unscoped_id(id), alias_set), collect(keys(sources))), by=preferred_id_sort)
+        if isempty(ids)
+            # This can happen when re-searching a published JLSEC whose sources could not be re-fetched
+            @warn "no fetched advisories correspond to an alias set; skipping it" alias_set
+            continue
+        end
         start_id = popfirst!(ids)
         advisory = sources[start_id]
         for id in ids

--- a/src/common.jl
+++ b/src/common.jl
@@ -698,7 +698,6 @@ function fetch_combinations(batch)
         # source ids (owner/repo/GHSA-xxxx) match their plain GHSA aliases
         ids = sort(filter(id -> any(a -> unscoped_id(a) == unscoped_id(id), alias_set), collect(keys(sources))), by=preferred_id_sort)
         if isempty(ids)
-            # This can happen when re-searching a published JLSEC whose sources could not be re-fetched
             @warn "no fetched advisories correspond to an alias set; skipping it" alias_set
             continue
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -177,8 +177,7 @@ end
 end
 
 @testset "fetch_combinations skips alias sets with no fetchable sources" begin
-    # A published JLSEC whose aliases can't be re-fetched shouldn't error; it's updated
-    # via `find_existing_jlsec` downstream rather than through re-combination
+    # A published JLSEC whose aliases can't be re-fetched shouldn't error
     batch = tryparse.(SecurityAdvisories.Advisory, [
         "```toml\nschema_version = \"1.8.0\"\nid = \"JLSEC-2026-12345\"\nmodified = 2026-07-23T19:36:30.000Z\npublished = 2026-07-23T19:36:30.000Z\naliases = [\"PYSEC-2026-99999\"]\n\n[[affected]]\npkg = \"Example\"\nranges = [\"< 1.0.0\"]\n\n[[jlsec_sources]]\nid = \"PYSEC-2026-99999\"\nimported = 2026-07-23T19:36:30.000Z\nmodified = 2026-07-23T15:00:00.000Z\npublished = 2026-07-23T15:00:00.000Z\nurl = \"https://example.com/PYSEC-2026-99999\"\nhtml_url = \"https://example.com/PYSEC-2026-99999\"\n```\n\n# Some advisory\n"])
     combined = @test_logs (:info,) (:warn, r"no fetched advisories") SecurityAdvisories.fetch_combinations(batch)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -166,6 +166,25 @@ end
     @test "PYSEC-2026-575" in only(combined).aliases
 end
 
+@testset "fetch_combinations of repository GHSAs" begin
+    # Repository GHSAs are keyed by a repo-scoped `srcid` (owner/repo/GHSA-...) but their
+    # aliases only list the plain GHSA id; the two must still be recognized as the same advisory
+    batch = tryparse.(SecurityAdvisories.Advisory, [
+        "```toml\nschema_version = \"1.8.0\"\nid = \"JLSEC-0000-GHSA-r3xx-hw22-6h6w\"\nmodified = 2026-07-23T19:36:30.000Z\naliases = [\"GHSA-r3xx-hw22-6h6w\"]\n\n[[affected]]\npkg = \"LibSSH\"\nranges = [\"< 1.1.0\"]\n\n[[jlsec_sources]]\nid = \"GHSA-r3xx-hw22-6h6w\"\nimported = 2026-07-23T19:36:30.000Z\nmodified = 2026-07-23T15:00:00.000Z\npublished = 2026-07-23T15:00:00.000Z\nurl = \"https://api.github.com/repos/JuliaWeb/LibSSH.jl/security-advisories/GHSA-r3xx-hw22-6h6w\"\nhtml_url = \"https://github.com/JuliaWeb/LibSSH.jl/security/advisories/GHSA-r3xx-hw22-6h6w\"\n```\n\n# Writing to SFTP files resulting in sending out-of-bounds data to the server\n"])
+    combined = SecurityAdvisories.fetch_combinations(batch)
+    @test length(combined) == 1
+    @test "GHSA-r3xx-hw22-6h6w" in only(combined).aliases
+end
+
+@testset "fetch_combinations skips alias sets with no fetchable sources" begin
+    # A published JLSEC whose aliases can't be re-fetched shouldn't error; it's updated
+    # via `find_existing_jlsec` downstream rather than through re-combination
+    batch = tryparse.(SecurityAdvisories.Advisory, [
+        "```toml\nschema_version = \"1.8.0\"\nid = \"JLSEC-2026-12345\"\nmodified = 2026-07-23T19:36:30.000Z\npublished = 2026-07-23T19:36:30.000Z\naliases = [\"PYSEC-2026-99999\"]\n\n[[affected]]\npkg = \"Example\"\nranges = [\"< 1.0.0\"]\n\n[[jlsec_sources]]\nid = \"PYSEC-2026-99999\"\nimported = 2026-07-23T19:36:30.000Z\nmodified = 2026-07-23T15:00:00.000Z\npublished = 2026-07-23T15:00:00.000Z\nurl = \"https://example.com/PYSEC-2026-99999\"\nhtml_url = \"https://example.com/PYSEC-2026-99999\"\n```\n\n# Some advisory\n"])
+    combined = @test_logs (:info,) (:warn, r"no fetched advisories") SecurityAdvisories.fetch_combinations(batch)
+    @test isempty(combined)
+end
+
 using SecurityAdvisories: Advisory, PackageVulnerability, VersionString, recipe_update_candidates
 using DataStructures: OrderedDict
 @testset "recipe update candidates" begin


### PR DESCRIPTION
Since 07eccd20, fetch_combinations keyed its sources by srcid, which returns the repo-scoped owner/repo/GHSA-xxxx form for repository advisories. Those advisories only record their plain GHSA id in their aliases/upstreams, so the alias set never intersected the source keys and popfirst! crashed on an empty array — breaking every import of a repository GHSA that isn't in the global advisory database.

Key imported advisories by their plain source id again (published JLSECs keep their JLSEC id), and resolve referenced ids through the batch sources' repo-scoped srcids so that re-searching a published JLSEC can re-fetch its repository-GHSA sources from the repository endpoint rather than failing against the global database. Also skip, with a warning, alias sets for which no source could be fetched instead of erroring.