### PR TITLE
Draft Reseau security advisories

### DIFF
--- a/advisories/published/2026/JLSEC-0000-0.md
+++ b/advisories/published/2026/JLSEC-0000-0.md
@@ -1,0 +1,81 @@
+```toml
+schema_version = "1.8.0"
+id = "JLSEC-0000-0"
+aliases = ["ANT-2026-A9EKTB8C", "ANT-2026-KA1TSJPQ"]
+references = ["https://github.com/JuliaServices/Reseau.jl/pull/132", "https://github.com/JuliaServices/Reseau.jl/commit/ea95f091baaf7386267fd633742768121dfe20ff", "https://github.com/JuliaServices/Reseau.jl/pull/135", "https://github.com/JuliaServices/Reseau.jl/commit/9add20c1f39ecba430c9aa1dcd399191ccaeb76b", "https://github.com/JuliaServices/Reseau.jl/releases/tag/v1.3.3"]
+
+[[affected]]
+pkg = "Reseau"
+ranges = [">= 1.0.0, < 1.3.3"]
+
+[[credits]]
+name = "Julia Security Team in collaboration with Claude and Anthropic Research"
+type = "FINDER"
+```
+
+# Windows IOCP lifetime bugs can corrupt memory during cancellation or shutdown
+
+Reseau releases before 1.3.3 contain related lifetime defects in the Windows I/O
+completion port (IOCP) backend. During cancellation or event-loop shutdown, the
+package can stop retaining memory that the Windows kernel still owns. A remote
+peer that can time or stall I/O around application-driven deadlines, concurrent
+closes, or event-loop shutdown may be able to trigger these races. Linux,
+macOS, and FreeBSD use different polling backends and are not affected.
+
+### Impact
+
+Depending on the interleaving, the kernel can write network data or completion
+status into reclaimed Julia heap memory. The resulting memory corruption can
+crash the process and may also cause information disclosure or code execution,
+although no reliable exploit was demonstrated.
+
+Exploitation is timing-dependent. The most direct raw-buffer corruption path
+also requires a read or write deadline to race with a concurrent close or
+eviction of the same file descriptor.
+
+### Technical details
+
+This advisory consolidates two variants of the same kernel-ownership failure:
+
+1. `WSARecv` and `WSASend` received pointers into caller-owned buffers that were
+   preserved only for the dynamic extent of the Julia call. A cancellation
+   wake could be consumed before the kernel's completion packet, allowing the
+   call to unwind and the buffer to be collected while the kernel still owned
+   its address. Direct overlapped reads and writes, including this path, first
+   shipped in Reseau 1.1.3.
+2. Event-loop shutdown closed the completion port and discarded the objects
+   that rooted pending `OVERLAPPED` structures without first canceling and
+   draining all kernel-owned operations.
+
+Reseau 1.3.2 added roots for object-backed reads and writes and implemented
+synchronous shutdown draining, but pointer-only operations still supplied no
+retained buffer root. During shutdown, their cancellation wait could lose
+access to the registration and return before the backend drain finished. That
+release could also treat `CancelIoEx` returning `ERROR_NOT_FOUND` as terminal
+while the completion packet was queued or had been dequeued by the poller but
+not yet consumed. Clearing the operation's active state at that point permitted
+live `OVERLAPPED` storage to be reset or reused. Separately, a finish path could
+observe a terminal `WSAGetOverlappedResult` after the poller dequeued a packet
+and reset the storage before the poller retired the old operation.
+Consequently, 1.3.2 is still included in the affected range.
+
+### Patches
+
+Upgrade to Reseau 1.3.3 or later. The complete fix:
+
+- uses bounded, operation-owned buffers for raw reads and writes and retains
+  buffer roots until completion consumption;
+- synchronously cancels and drains every outstanding operation before dropping
+  backend roots; and
+- permits only the completion consumer to clear an active operation, preventing
+  premature `OVERLAPPED` reuse.
+
+### Workarounds
+
+There is no complete Windows workaround that preserves use of the vulnerable
+IOCP backend. Running the service on a non-Windows backend avoids these defects.
+Avoiding concurrent close/deadline operations reduces exposure to the
+raw-buffer race but does not address the shutdown variant.
+
+Reported to the JuliaLang security team through Anthropic's Coordinated
+Vulnerability Disclosure program.

--- a/advisories/published/2026/JLSEC-0000-1.md
+++ b/advisories/published/2026/JLSEC-0000-1.md
@@ -1,0 +1,59 @@
+```toml
+schema_version = "1.8.0"
+id = "JLSEC-0000-1"
+aliases = ["ANT-2026-DEPR14J5"]
+references = ["https://github.com/JuliaServices/Reseau.jl/pull/132", "https://github.com/JuliaServices/Reseau.jl/commit/ea95f091baaf7386267fd633742768121dfe20ff", "https://github.com/JuliaServices/Reseau.jl/releases/tag/v1.3.2"]
+
+[[affected]]
+pkg = "Reseau"
+ranges = [">= 1.1.0, < 1.3.2"]
+
+[[credits]]
+name = "Julia Security Team in collaboration with Claude and Anthropic Research"
+type = "FINDER"
+```
+
+# TLS 1.3 KeyUpdate handling can race concurrent writes
+
+Reseau 1.1.0 through 1.3.1 process a peer-requested TLS 1.3
+`KeyUpdate(update_requested)` response from the read path without acquiring the
+connection's write lock. A connected peer can race that response against an
+application task writing on the same connection.
+
+### Impact
+
+The two tasks can concurrently use and replace shared write-cipher state,
+including the record sequence number, nonce and output buffers, key material,
+and OpenSSL AEAD context. Depending on timing, this can cause AEAD nonce reuse,
+corrupted or disclosed plaintext, use-after-free behavior in OpenSSL, or
+process termination.
+
+The attack requires TLS 1.3, concurrent reader and writer tasks, and winning a
+race with an otherwise valid post-handshake KeyUpdate message.
+
+### Technical details
+
+Application writes hold `conn.write_lock`, but the vulnerable KeyUpdate handler
+wrote its response and called `_tls13_advance_write_cipher!` while holding only
+the read lock. The application writer and handler could therefore encrypt with
+the same sequence number, resize a shared output buffer while another task held
+its pointer across an I/O yield, or free and replace an EVP context still in
+use by the writer.
+
+The vulnerable native TLS implementation first shipped in Reseau 1.1.0.
+Releases 1.0.x used the previous OpenSSL TLS engine and are not affected.
+
+### Patches
+
+Upgrade to Reseau 1.3.2 or later. The fix serializes both the KeyUpdate response
+and write-cipher rotation under the same write lock used by application writes.
+
+### Workarounds
+
+Configuring connections to use TLS 1.2, or ensuring that no application writer
+runs concurrently with the connection reader, avoids this particular race.
+Upgrading is recommended because those restrictions can be difficult to
+enforce for full-duplex protocols.
+
+Reported to the JuliaLang security team through Anthropic's Coordinated
+Vulnerability Disclosure program.

--- a/advisories/published/2026/JLSEC-0000-2.md
+++ b/advisories/published/2026/JLSEC-0000-2.md
@@ -1,0 +1,63 @@
+```toml
+schema_version = "1.8.0"
+id = "JLSEC-0000-2"
+aliases = ["ANT-2026-9AY5SJ8K", "ANT-2026-Y2QRZ3CC"]
+references = ["https://github.com/JuliaServices/Reseau.jl/pull/132", "https://github.com/JuliaServices/Reseau.jl/commit/ea95f091baaf7386267fd633742768121dfe20ff", "https://github.com/JuliaServices/Reseau.jl/releases/tag/v1.3.2"]
+
+[[affected]]
+pkg = "Reseau"
+ranges = [">= 1.1.0, < 1.3.2"]
+
+[[credits]]
+name = "Julia Security Team in collaboration with Claude and Anthropic Research"
+type = "FINDER"
+```
+
+# Unauthenticated TLS records can exhaust memory or CPU during a handshake
+
+Reseau 1.1.0 through 1.3.1 contain two resource-exhaustion conditions in the
+native TLS 1.2 and TLS 1.3 record layers. An unauthenticated network peer can
+send records that consume memory without a bound or keep a handshake task
+processing non-progressing input.
+
+### Impact
+
+A peer can retain approximately 16 KiB of plaintext per record until the
+process exhausts memory, or stream empty handshake records to keep a connection
+task consuming CPU. Multiple connections can amplify either condition and
+impair service availability.
+
+### Technical details
+
+This advisory consolidates two handshake-time input-validation defects:
+
+1. After obtaining handshake traffic keys but before completing the handshake,
+   a peer could send application-data records. The record layers appended the
+   decrypted bytes to an unbounded plaintext buffer instead of rejecting the
+   record. Because each record was nonempty, it also reset the useless-record
+   counter.
+2. Zero-length handshake records produced no handshake bytes but were not
+   rejected or charged against the useless-record limit. The handshake reader
+   could therefore loop forever while continuing to receive non-progressing
+   records.
+
+Both defects were introduced with Reseau's native TLS stack in version 1.1.0.
+Releases 1.0.x used the previous OpenSSL TLS engine and are not affected.
+
+### Patches
+
+Upgrade to Reseau 1.3.2 or later. The fixed record layers reject both
+application data received before handshake completion and empty handshake
+records with a fatal `unexpected_message` alert.
+
+### Workarounds
+
+There is no complete in-process workaround. Set a finite
+`handshake_timeout_ns` and enforce connection rate and concurrency limits to
+bound each handshake's duration and reduce repeated attacks; an attacker can
+still consume substantial resources within that window. Terminating TLS in a
+patched proxy before forwarding traffic to a vulnerable Reseau service avoids
+the vulnerable record parser.
+
+Reported to the JuliaLang security team through Anthropic's Coordinated
+Vulnerability Disclosure program.

--- a/advisories/published/2026/JLSEC-0000-3.md
+++ b/advisories/published/2026/JLSEC-0000-3.md
@@ -1,0 +1,56 @@
+```toml
+schema_version = "1.8.0"
+id = "JLSEC-0000-3"
+aliases = ["ANT-2026-FPFYHMMM"]
+references = ["https://github.com/JuliaServices/Reseau.jl/pull/132", "https://github.com/JuliaServices/Reseau.jl/commit/ea95f091baaf7386267fd633742768121dfe20ff", "https://github.com/JuliaServices/Reseau.jl/releases/tag/v1.3.2"]
+
+[[affected]]
+pkg = "Reseau"
+ranges = [">= 1.0.0, < 1.3.2"]
+
+[[credits]]
+name = "Julia Security Team in collaboration with Claude and Anthropic Research"
+type = "FINDER"
+```
+
+# Slow DNS lookups can stall garbage collection process-wide
+
+Reseau 1.0.0 through 1.3.1 perform the blocking system `getaddrinfo` operation
+from Julia-adopted resolver threads without marking the foreign call as
+garbage-collector safe. An attacker who can cause an application to resolve a
+slow hostname can delay stop-the-world garbage collection for the entire
+process.
+
+### Impact
+
+While a resolver worker is blocked outside a GC-safe region, a collection
+requested by any thread can stall all Julia execution until the
+operating-system resolver returns. Repeated slow lookups can cause severe
+service latency or temporary denial of service. Each individual stall remains
+bounded by the operating system's DNS timeout.
+
+Exploitation requires either attacker influence over hostnames the application
+resolves or control of a relevant DNS response path.
+
+### Technical details
+
+Reseau uses a native resolver pool whose worker threads enter Julia through
+`@cfunction`. The POSIX and Winsock resolver wrappers called `getaddrinfo` with
+a plain `ccall`. Because the adopted thread could not reach a safepoint while
+the resolver blocked, Julia's collector had to wait for it.
+
+### Patches
+
+Upgrade to Reseau 1.3.2 or later. The resolver now uses Reseau's
+`@gcsafe_ccall` wrapper for the blocking system call on both POSIX and Windows.
+
+### Workarounds
+
+Reject or strictly allowlist attacker-supplied hostnames before resolution and
+cache validated DNS results where appropriate. Isolating untrusted resolution
+in a separate process also prevents its resolver timeout from blocking the
+main Julia process. These measures are application-dependent; upgrading is the
+complete fix.
+
+Reported to the JuliaLang security team through Anthropic's Coordinated
+Vulnerability Disclosure program.

--- a/advisories/published/2026/JLSEC-0000-4.md
+++ b/advisories/published/2026/JLSEC-0000-4.md
@@ -1,0 +1,62 @@
+```toml
+schema_version = "1.8.0"
+id = "JLSEC-0000-4"
+aliases = ["ANT-2026-23T10288"]
+references = ["https://github.com/JuliaServices/Reseau.jl/pull/132", "https://github.com/JuliaServices/Reseau.jl/commit/ea95f091baaf7386267fd633742768121dfe20ff", "https://github.com/JuliaServices/Reseau.jl/releases/tag/v1.3.2"]
+
+[[affected]]
+pkg = "Reseau"
+ranges = [">= 1.1.0, < 1.3.2"]
+
+[[credits]]
+name = "Julia Security Team in collaboration with Claude and Anthropic Research"
+type = "FINDER"
+```
+
+# Native TLS accepts undersized or malformed RSA certificate public keys
+
+Reseau 1.1.0 through 1.3.1 enforce an upper bound on RSA certificate keys but no
+minimum modulus size and no sanity checks on the public exponent. A certificate
+chain containing a factorable RSA key can therefore pass Reseau's key-strength
+checks.
+
+### Impact
+
+Exploitation requires a weak RSA key to exist in a certificate chain the
+endpoint already trusts. An attacker who factors that key can forge certificate
+or TLS-handshake signatures, depending on where the weak key appears, and
+impersonate a peer. Exposure is primarily in private certificate authorities
+and legacy or misconfigured deployments; modern public certificate authorities
+do not normally issue sub-1024-bit RSA keys.
+
+### Technical details
+
+The native X.509 parser rejected RSA moduli larger than 8192 bits, but accepted
+arbitrarily small moduli and public exponents smaller than three or divisible
+by two. Those keys could then be used for certificate-chain and TLS-handshake
+signature verification.
+
+This validation path was introduced with Reseau's native TLS stack in version
+1.1.0. Releases 1.0.x used the previous OpenSSL TLS engine and are not affected.
+
+### Patches
+
+Upgrade to Reseau 1.3.2 or later. The fixed parser rejects RSA certificate keys
+smaller than 1024 bits and rejects public exponents that are smaller than three
+or even.
+
+Applications with stronger policy requirements should independently require
+at least 2048-bit RSA keys; the package's patched 1024-bit floor is a
+compatibility baseline, not a modern key-size recommendation.
+
+### Workarounds
+
+Validate every RSA public key in the deployed certificate and trust chains
+out-of-band for an adequate modulus size and a valid odd exponent, or restrict
+the trust store to certificate authorities that enforce such a policy.
+Affected Reseau releases do not expose a configuration callback for performing
+this validation during a handshake. Deployments using only non-RSA certificate
+chains avoid this issue.
+
+Reported to the JuliaLang security team through Anthropic's Coordinated
+Vulnerability Disclosure program.

--- a/advisories/published/2026/JLSEC-0000-5.md
+++ b/advisories/published/2026/JLSEC-0000-5.md
@@ -1,0 +1,61 @@
+```toml
+schema_version = "1.8.0"
+id = "JLSEC-0000-5"
+aliases = ["ANT-2026-5NJRQ19H"]
+references = ["https://github.com/JuliaServices/Reseau.jl/pull/132", "https://github.com/JuliaServices/Reseau.jl/commit/ea95f091baaf7386267fd633742768121dfe20ff", "https://github.com/JuliaServices/Reseau.jl/releases/tag/v1.3.2"]
+
+[[affected]]
+pkg = "Reseau"
+ranges = [">= 1.1.0, < 1.3.2"]
+
+[[credits]]
+name = "Julia Security Team in collaboration with Claude and Anthropic Research"
+type = "FINDER"
+```
+
+# TLS 1.2 session resumption can renew one master secret indefinitely
+
+Reseau 1.1.0 through 1.3.1 issue a fresh TLS 1.2 session ticket after a resumed
+handshake by copying the original master secret while resetting the ticket's
+creation and expiry times. A client that resumes at least once during every
+ticket lifetime can keep the same master secret valid indefinitely.
+
+### Impact
+
+Indefinite renewal weakens the intended bound on a resumption secret's lifetime
+and erodes forward secrecy. If that master secret, or the server's
+ticket-encryption key together with a usable ticket, is later compromised, an
+attacker may be able to decrypt a much larger window of captured
+resumed-session traffic than the configured ticket lifetime suggests.
+
+The issue does not by itself disclose a ticket or secret; the attacker must
+first possess a valid ticket or obtain the relevant key material.
+
+### Technical details
+
+The resumed-server handshake copied the cached session's `master_secret` into a
+new ticket but set `created_at` to the current time and `use_by` to seven days
+later. Because no absolute age was carried forward, chained resumptions renewed
+the same secret without limit.
+
+This ticket implementation was introduced with Reseau's native TLS stack in
+version 1.1.0. Releases 1.0.x used the previous OpenSSL TLS engine and are not
+affected.
+
+### Patches
+
+Upgrade to Reseau 1.3.2 or later. Resumed tickets now preserve the original
+secret's creation and expiry timestamps, and resumption is rejected once that
+absolute lifetime expires so that a full handshake establishes fresh key
+material.
+
+### Workarounds
+
+Set `session_tickets_disabled = true` in the TLS configuration, or configure
+the service to require TLS 1.3, until Reseau can be upgraded. Operators can
+also rotate ticket-encryption keys and force full handshakes more frequently,
+but that is less reliable than disabling the vulnerable TLS 1.2 resumption
+path.
+
+Reported to the JuliaLang security team through Anthropic's Coordinated
+Vulnerability Disclosure program.

--- a/advisories/published/2026/JLSEC-0000-6.md
+++ b/advisories/published/2026/JLSEC-0000-6.md
@@ -1,0 +1,60 @@
+```toml
+schema_version = "1.8.0"
+id = "JLSEC-0000-6"
+aliases = ["ANT-2026-JSEBXMP3"]
+references = ["https://github.com/JuliaServices/Reseau.jl/pull/132", "https://github.com/JuliaServices/Reseau.jl/commit/ea95f091baaf7386267fd633742768121dfe20ff", "https://github.com/JuliaServices/Reseau.jl/releases/tag/v1.3.2"]
+
+[[affected]]
+pkg = "Reseau"
+ranges = [">= 1.0.0, < 1.3.2"]
+
+[[credits]]
+name = "Julia Security Team in collaboration with Claude and Anthropic Research"
+type = "FINDER"
+```
+
+# Windows IOCP poller races unsynchronized registration tables
+
+Reseau 1.0.0 through 1.3.1 access the Windows I/O completion port (IOCP)
+backend's registration dictionary and zombie vector concurrently from the
+poller and application threads without consistently taking the same lock. A
+remote peer can increase the likelihood of the race by driving connection churn
+and I/O completions at the same time. Linux, macOS, and FreeBSD use different
+polling backends and are not affected.
+
+### Impact
+
+A dictionary rehash or vector mutation that overlaps the poller's unlocked
+lookup or cleanup can crash or corrupt the poller state. A stale or incorrect
+lookup can also associate a kernel completion with the wrong I/O operation,
+potentially causing cross-connection completion misdelivery.
+
+The outcome is probabilistic and timing-dependent; a peer can accelerate the
+race but does not directly control the conflicting interleaving.
+
+### Technical details
+
+Registration and deregistration mutated the IOCP backend's `by_ptr` dictionary
+and `zombies` vector while holding the shared poller-state lock. The dedicated
+poller thread looked up completions in `by_ptr` and removed completed
+registrations from those same non-thread-safe collections without taking that
+lock. Concurrent insertion could rehash the dictionary while it was being
+read, and concurrent zombie cleanup could mutate a vector being traversed or
+searched.
+
+### Patches
+
+Upgrade to Reseau 1.3.2 or later. The fixed IOCP dispatch path takes the shared
+poller-state lock around registration lookup, operation-state transition, and
+zombie cleanup, matching the synchronization used by the other polling
+backends.
+
+### Workarounds
+
+There is no complete Windows workaround that preserves use of the vulnerable
+IOCP backend. Running the service on a non-Windows backend avoids the race.
+Limiting connection churn can reduce its likelihood but does not make
+concurrent table access safe.
+
+Reported to the JuliaLang security team through Anthropic's Coordinated
+Vulnerability Disclosure program.


### PR DESCRIPTION
These security advisories were generated from the upstream reports. I think there is a bit of a question where the line between a bug and a security issue is, but I figure if they come in as security reports, might as well go out as them. Let me know if opinions differ. cc @quinnj