### PR TITLE
JLSEC-2025-6: re-evaluate severity attack vector

### DIFF
--- a/advisories/published/2025/JLSEC-2025-6.md
+++ b/advisories/published/2025/JLSEC-2025-6.md
@@ -5,15 +5,7 @@ modified = 2026-07-23T22:21:26.455Z
 published = 2025-10-08T17:41:37.190Z
 upstream = ["CVE-2021-4048"]
 references = ["https://github.com/JuliaLang/julia/issues/42415", "https://github.com/Reference-LAPACK/lapack/commit/38f3eeee3108b18158409ca2a100e6fe03754781", "https://github.com/Reference-LAPACK/lapack/pull/625", "https://github.com/xianyi/OpenBLAS/commit/2be5ee3cca97a597f2ee2118808a2d5eacea050c", "https://github.com/xianyi/OpenBLAS/commit/337b65133df174796794871b3988cd03426e6d41", "https://github.com/xianyi/OpenBLAS/commit/ddb0ff5353637bb5f5ad060c9620e334c143e3d7", "https://github.com/xianyi/OpenBLAS/commit/fe497efa0510466fd93578aaf9da1ad8ed4edbe7", "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/6QFEVOCUG2UXMVMFMTU4ONJVDEHY2LW2/", "https://lists.fedoraproject.org/archives/list/package-announce%40lists.fedoraproject.org/message/DROZM4M2QRKSD6FBO4BHSV2QMIRJQPHT/"]
-
-[[severity]]
-type = "CVSS_V2"
-score = "AV:N/AC:L/Au:N/C:P/I:N/A:P"
-source = "NVD"
-[[severity]]
-type = "CVSS_V3"
-score = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H"
-source = "NVD"
+severity = ["CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H", "AV:L/AC:L/Au:N/C:P/I:N/A:P"]
 
 [[affected]]
 pkg = "LAPACK32_jll"


### PR DESCRIPTION
Given the trust model of these packages, I think this would be better described as a local attack vector.

This downgrades the v3.1 scoring from [9.1 (Critical)](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H&version=3.1) to [7.7](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:L/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H&version=3.1)