### PR TITLE
Reject CVE-2021-4048 for the ReferenceBLAS JLL packages

### DIFF
--- a/advisories/published/2025/JLSEC-2025-6.md
+++ b/advisories/published/2025/JLSEC-2025-6.md
@@ -40,12 +40,6 @@ ranges = ["*"]
 pkg = "OpenBLAS_jll"
 ranges = ["< 0.3.20+0"]
 [[affected]]
-pkg = "ReferenceBLAS32_jll"
-ranges = ["< 3.12.1+0"]
-[[affected]]
-pkg = "ReferenceBLAS_jll"
-ranges = ["< 3.12.1+0"]
-[[affected]]
 pkg = "libjulia_jll"
 ranges = ["< 1.8.0+1"]
 

--- a/advisories/rejected.toml
+++ b/advisories/rejected.toml
@@ -21,17 +21,8 @@ packages = ["Kerberos_krb5_jll"]
 reason = "Affects krb5 through 1.16, predating the earliest krb5 packaged as Kerberos_krb5_jll (1.19.3). It only matched because NVD folds the '5' of krb5 into its version numbers, preventing a bounded mapping. Reviewed in #354."
 
 [CVE-2021-4048]
-packages = ["SLICOT_jll"]
-reason = "SLICOT_jll's buildscript only extracts and builds three routines; these do not include the vulnerable `*ARRV` family. Ref https://github.com/JuliaPackaging/Yggdrasil/blob/31d7ae44c2fc697b3d53d08dd6b02c69d46b69bd/S/SLICOT/build_tarballs.jl#L30-L31"
-
-[CVE-2021-4048]
-packages = ["ReferenceBLAS32_jll"]
-reason = "ReferenceBLAS32_jll only contains the BLAS routines, not LAPACK routines; these do not include the vulnerable `*ARRV` family. Ref https://github.com/JuliaPackaging/Yggdrasil/blob/fc9bcdfd56ec869e741bc4c7e1866c287bfbfd01/R/ReferenceBLAS/common.jl#L48-52"
-
-[CVE-2021-4048]
-packages = ["ReferenceBLAS_jll"]
-reason = "ReferenceBLAS_jll only contains the BLAS routines, not LAPACK routines; these do not include the vulnerable `*ARRV` family. Ref https://github.com/JuliaPackaging/Yggdrasil/blob/fc9bcdfd56ec869e741bc4c7e1866c287bfbfd01/R/ReferenceBLAS/common.jl#L48-52"
-
+packages = ["SLICOT_jll", "ReferenceBLAS32_jll", "ReferenceBLAS_jll"]
+reason = "These packages do not build or redistribute the vulnerable `*ARRV` family. Ref https://github.com/JuliaPackaging/Yggdrasil/blob/31d7ae44c2fc697b3d53d08dd6b02c69d46b69bd/S/SLICOT/build_tarballs.jl#L30-L31 and https://github.com/JuliaPackaging/Yggdrasil/blob/fc9bcdfd56ec869e741bc4c7e1866c287bfbfd01/R/ReferenceBLAS/common.jl#L48-52"
 [CVE-2023-52353]
 packages = ["MbedTLS_jll"]
 reason = "Only applies when TLS 1.3 is enabled, per the Debian security team; MbedTLS_jll ships the 2.x series, which does not support TLS 1.3. Reviewed in #202 and #465."

--- a/advisories/rejected.toml
+++ b/advisories/rejected.toml
@@ -24,6 +24,14 @@ reason = "Affects krb5 through 1.16, predating the earliest krb5 packaged as Ker
 packages = ["SLICOT_jll"]
 reason = "SLICOT_jll's buildscript only extracts and builds three routines; these do not include the vulnerable `*ARRV` family. Ref https://github.com/JuliaPackaging/Yggdrasil/blob/31d7ae44c2fc697b3d53d08dd6b02c69d46b69bd/S/SLICOT/build_tarballs.jl#L30-L31"
 
+[CVE-2021-4048]
+packages = ["ReferenceBLAS32_jll"]
+reason = "ReferenceBLAS32_jll only contains the BLAS routines, not LAPACK routines; these do not include the vulnerable `*ARRV` family. Ref https://github.com/JuliaPackaging/Yggdrasil/blob/fc9bcdfd56ec869e741bc4c7e1866c287bfbfd01/R/ReferenceBLAS/common.jl#L48-52"
+
+[CVE-2021-4048]
+packages = ["ReferenceBLAS_jll"]
+reason = "ReferenceBLAS_jll only contains the BLAS routines, not LAPACK routines; these do not include the vulnerable `*ARRV` family. Ref https://github.com/JuliaPackaging/Yggdrasil/blob/fc9bcdfd56ec869e741bc4c7e1866c287bfbfd01/R/ReferenceBLAS/common.jl#L48-52"
+
 [CVE-2023-52353]
 packages = ["MbedTLS_jll"]
 reason = "Only applies when TLS 1.3 is enabled, per the Debian security team; MbedTLS_jll ships the 2.x series, which does not support TLS 1.3. Reviewed in #202 and #465."


### PR DESCRIPTION
ReferenceBLAS_jll and ReferenceBLAS32_jll only contain the libblas library, which is the BLAS level 1/2/3 functions. The LAPACK library is forcefully deleted during the build, so the vulnerable functions are not included in the resulting package.