### PR TITLE
Stop hardcoding site identity outside web/config.md

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -41,8 +41,6 @@ jobs:
           julia --project=. pre_generate.jl --clean
 
       - name: Build site
-        env:
-          FRANKLIN_PREPATH: SecurityAdvisories.jl
         run: |
           cd web
           julia --project=. -e 'using Franklin; optimize(prerender=true, minify=false)'

--- a/web/_layout/head.html
+++ b/web/_layout/head.html
@@ -24,12 +24,12 @@
     html[data-theme="dark"] { background-color: #1a1b2e; color: #d0d4e0; }
     body { background-color: transparent !important; color: inherit !important; margin: 0; }
   </style>
-  <title>{{isnotpage /}}{{fill title}} &middot; {{end}}Julia Ecosystem Security Advisories</title>
+  <title>{{isnotpage /}}{{fill title}} &middot; {{end}}{{website_title}}</title>
   <link rel="icon" type="image/png" href="/assets/favicon.png">
   <link rel="stylesheet" href="/css/site.css">
   <link rel="stylesheet" href="/pagefind/pagefind-ui.css" media="print" onload="this.media='all'">
   <script src="/pagefind/pagefind-ui.js" defer></script>
-  <link rel="alternate" type="application/rss+xml" title="Julia Ecosystem Security Advisories" href="/feed.xml">
+  <link rel="alternate" type="application/rss+xml" title="{{website_title}}" href="/feed.xml">
 </head>
 
 <body>


### PR DESCRIPTION
Drop the FRANKLIN_PREPATH=SecurityAdvisories.jl override from the deploy workflow — a leftover from github.io project-page hosting that would prefix every link and sitemap/robots/feed URL now that the site serves at the root of its own domain. config.md already defaults prepath to "".

Use {{website_title}} in the layout head instead of repeating the title.