### PR TITLE
Fix JLSEC-2026-1171's affected ranges for ffmpeg*

### DIFF
--- a/advisories/published/2026/JLSEC-2026-1171.md
+++ b/advisories/published/2026/JLSEC-2026-1171.md
@@ -17,10 +17,10 @@ source = "CNA"
 
 [[affected]]
 pkg = "FFMPEG_jll"
-ranges = ["*"]
+ranges = ["< 9.0.0+0"]
 [[affected]]
 pkg = "FFMPEG_nogpl_jll"
-ranges = ["*"]
+ranges = ["< 9.0.0+0"]
 [[affected]]
 pkg = "FFplay_jll"
 ranges = ["*"]


### PR DESCRIPTION
The original search import here — #640 — had tried to use a raw git commit to compute this version range.  But it's worse than just that; the upstream advisory (https://euvd.enisa.europa.eu/vulnerability/EUVD-2026-39969) cites the wrong fix commit.

- The cited commit [`bcd2c69e`](https://github.com/FFmpeg/FFmpeg/commit/bcd2c69e087a09b07cf45c6bd2428ee1ccb2925c) is "avcodec/d3d12va: fix reference-only resource pool exhaustion" — unrelated to the RASC `decode_dlta` out-of-bounds bug, and present only on `master` (no release tag contains it).
- The actual fix is [`11ff18a6`](https://github.com/FFmpeg/FFmpeg/commit/11ff18a6c80187405fc492f9bb07ba9f2f663f76) "avcodec/rasc: Check that 32-bit DLTA accesses stay within the row". Its commit message credits `Found-by: bikini (github.com/bikini/exploitarium)`, matching the PoC referenced by the advisory.
- That fix was cherry-picked onto `release/9.0` as [`f8d7795d`](https://github.com/FFmpeg/FFmpeg/commit/f8d7795dcca36a4dd412e89cbd83e3dfec1e0d81) ("cherry picked from commit 11ff18a6…"; `git patch-id` confirms an identical diff), and it is reachable from the `n9.0` tag — see [the history of `libavcodec/rasc.c` at `n9.0`](https://github.com/FFmpeg/FFmpeg/commits/n9.0/libavcodec/rasc.c).
- No 8.x release contains the fix: it's absent from [`rasc.c` history at `n8.1.2`](https://github.com/FFmpeg/FFmpeg/commits/n8.1.2/libavcodec/rasc.c) and [at `n8.0.3`](https://github.com/FFmpeg/FFmpeg/commits/n8.0.3/libavcodec/rasc.c), and no other backport of this patch exists in the repo.