### PR TITLE
Run upstream advisory searches one at a time

### DIFF
--- a/.github/workflows/search-upstream-advisories.yml
+++ b/.github/workflows/search-upstream-advisories.yml
@@ -18,6 +18,11 @@ on:
 permissions:
   contents: read
 
+# Only allow one search to run at a time; queue subsequent runs
+concurrency:
+  group: search-upstream-advisories
+  cancel-in-progress: false
+
 jobs:
   identify-advisories:
     name: >-


### PR DESCRIPTION
Add a concurrency group so scheduled and manually-dispatched searches queue behind an in-progress run instead of running in parallel.