### PR TITLE
JLSEC-2026-249: AppBundler is not affected

### DIFF
--- a/advisories/published/2026/JLSEC-2026-249.md
+++ b/advisories/published/2026/JLSEC-2026-249.md
@@ -12,9 +12,6 @@ score = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
 source = "CNA"
 
 [[affected]]
-pkg = "AppBundler"
-ranges = ["*"]
-[[affected]]
 pkg = "OpenSSL_jll"
 ranges = ["< 3.0.15+0"]
 [[affected]]


### PR DESCRIPTION
This was not caught by #660 because the upstream advisory tightened its bounds — it was _never_ applicable to AppBundler in the first place!

So that automated action trusted the existing `*` instead of removing it.